### PR TITLE
UseTimerSelect hook for phone VR usage

### DIFF
--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -23,7 +23,7 @@ export type XRInteractionType = 'onHover' | 'onBlur'
 
 export type XRInteractionHandler = (event: XRInteractionEvent) => any
 
-export const useTimer = (callback: (argument: any) => void, data: { status: boolean; date: number }, timerTime: number) => {
+export const useTimer = (callback: () => void, data: { status: boolean; date: number }, timerTime: number) => {
   const { status, date } = data
   const [timerPercentage, setTimePercentage] = useState(0)
   useFrame(() => {

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -23,7 +23,7 @@ export type XRInteractionType = 'onHover' | 'onBlur'
 
 export type XRInteractionHandler = (event: XRInteractionEvent) => any
 
-export const useTimer = (callback: () => void, data: { status: boolean; startTime: number }, timerTime: number) => {
+export const useTimerSelect = (callback: () => void, data: { status: boolean; startTime: number }, timerTime: number) => {
   const { status, startTime } = data
   const [timerPercentage, setTimePercentage] = useState(0)
   useFrame(() => {
@@ -31,7 +31,7 @@ export const useTimer = (callback: () => void, data: { status: boolean; startTim
       const top = startTime + timerTime * 1000 - Date.now() - 5000
       const bottom = timerTime * 1000
 
-      setTimePercentage(Math.abs(top < -timerTime * 1000 ? -timerTime * 1000 : top / bottom))
+      setTimePercentage(Math.abs((top < -timerTime * 1000 ? -timerTime * 1000 : top) / bottom))
 
       if (startTime - Date.now() <= -timerTime * 1000 && startTime - Date.now() >= -timerTime * 1000 - 20) {
         callback()

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useState} from 'react'
 import { Object3D, Matrix4, Raycaster, Intersection } from 'three'
 import { Canvas, useThree, useFrame } from 'react-three-fiber'
 import { ARButton } from 'three/examples/jsm/webxr/ARButton'
@@ -21,6 +22,38 @@ export interface XRInteractionEvent {
 export type XRInteractionType = 'onHover' | 'onBlur'
 
 export type XRInteractionHandler = (event: XRInteractionEvent) => any
+
+const useTimer = (callback: (argument: any) => void, obj :{ status: boolean, date: number }, timerTime: number) => {
+  const [timerPercentage, setTimePercentage] = useState(0);
+  useFrame(() => {
+    if (status) {
+      
+
+      const top = date + timerTime * 1000 - Date.now() - 5000;
+      const bottom = timerTime * 1000;
+      // console.log("top", top, "bottom", bottom);
+
+      setTimePercentage(
+        Math.abs(top < -timerTime * 1000 ? -timerTime * 1000 : top / bottom)
+      );
+      // console.log(status, timerPercentage);
+
+      if (
+        date - Date.now() <= -timerTime * 1000 &&
+        date - Date.now() >= -timerTime * 1000 - 20
+      ) {
+        // console.log("timer fire");
+        // console.log(status);
+        callback();
+      }
+    } else {
+      setTimePercentage(0);
+    }
+  });
+  //also return time status maybe callback info
+  return timerPercentage;
+  })
+}
 
 const useControllers = (): XRController[] => {
   const { gl, scene } = useThree()

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useState} from 'react'
+import { useState } from 'react'
 import { Object3D, Matrix4, Raycaster, Intersection } from 'three'
 import { Canvas, useThree, useFrame } from 'react-three-fiber'
 import { ARButton } from 'three/examples/jsm/webxr/ARButton'
@@ -23,36 +23,29 @@ export type XRInteractionType = 'onHover' | 'onBlur'
 
 export type XRInteractionHandler = (event: XRInteractionEvent) => any
 
-const useTimer = (callback: (argument: any) => void, obj :{ status: boolean, date: number }, timerTime: number) => {
-  const [timerPercentage, setTimePercentage] = useState(0);
+const useTimer = (callback: (argument: any) => void, data: { status: boolean; date: number }, timerTime: number) => {
+  const { status, date } = data
+  const [timerPercentage, setTimePercentage] = useState(0)
   useFrame(() => {
     if (status) {
-      
-
-      const top = date + timerTime * 1000 - Date.now() - 5000;
-      const bottom = timerTime * 1000;
+      const top = date + timerTime * 1000 - Date.now() - 5000
+      const bottom = timerTime * 1000
       // console.log("top", top, "bottom", bottom);
 
-      setTimePercentage(
-        Math.abs(top < -timerTime * 1000 ? -timerTime * 1000 : top / bottom)
-      );
+      setTimePercentage(Math.abs(top < -timerTime * 1000 ? -timerTime * 1000 : top / bottom))
       // console.log(status, timerPercentage);
 
-      if (
-        date - Date.now() <= -timerTime * 1000 &&
-        date - Date.now() >= -timerTime * 1000 - 20
-      ) {
+      if (date - Date.now() <= -timerTime * 1000 && date - Date.now() >= -timerTime * 1000 - 20) {
         // console.log("timer fire");
         // console.log(status);
-        callback();
+        callback()
       }
     } else {
-      setTimePercentage(0);
+      setTimePercentage(0)
     }
-  });
-  //also return time status maybe callback info
-  return timerPercentage;
   })
+  //also return time status maybe callback info
+  return timerPercentage
 }
 
 const useControllers = (): XRController[] => {

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -30,14 +30,10 @@ export const useTimer = (callback: () => void, data: { status: boolean; date: nu
     if (status) {
       const top = date + timerTime * 1000 - Date.now() - 5000
       const bottom = timerTime * 1000
-      // console.log("top", top, "bottom", bottom);
 
       setTimePercentage(Math.abs(top < -timerTime * 1000 ? -timerTime * 1000 : top / bottom))
-      // console.log(status, timerPercentage);
 
       if (date - Date.now() <= -timerTime * 1000 && date - Date.now() >= -timerTime * 1000 - 20) {
-        // console.log("timer fire");
-        // console.log(status);
         callback()
       }
     } else {

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -23,7 +23,7 @@ export type XRInteractionType = 'onHover' | 'onBlur'
 
 export type XRInteractionHandler = (event: XRInteractionEvent) => any
 
-const useTimer = (callback: (argument: any) => void, data: { status: boolean; date: number }, timerTime: number) => {
+export const useTimer = (callback: (argument: any) => void, data: { status: boolean; date: number }, timerTime: number) => {
   const { status, date } = data
   const [timerPercentage, setTimePercentage] = useState(0)
   useFrame(() => {

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -23,17 +23,17 @@ export type XRInteractionType = 'onHover' | 'onBlur'
 
 export type XRInteractionHandler = (event: XRInteractionEvent) => any
 
-export const useTimer = (callback: () => void, data: { status: boolean; date: number }, timerTime: number) => {
-  const { status, date } = data
+export const useTimer = (callback: () => void, data: { status: boolean; startTime: number }, timerTime: number) => {
+  const { status, startTime } = data
   const [timerPercentage, setTimePercentage] = useState(0)
   useFrame(() => {
     if (status) {
-      const top = date + timerTime * 1000 - Date.now() - 5000
+      const top = startTime + timerTime * 1000 - Date.now() - 5000
       const bottom = timerTime * 1000
 
       setTimePercentage(Math.abs(top < -timerTime * 1000 ? -timerTime * 1000 : top / bottom))
 
-      if (date - Date.now() <= -timerTime * 1000 && date - Date.now() >= -timerTime * 1000 - 20) {
+      if (startTime - Date.now() <= -timerTime * 1000 && startTime - Date.now() >= -timerTime * 1000 - 20) {
         callback()
       }
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,10 +888,10 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.11.2":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
-  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+"@babel/runtime@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
+  integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -5474,35 +5474,35 @@ react-merge-refs@^1.1.0:
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
-react-reconciler@0.26.0-rc.0:
-  version "0.26.0-rc.0"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.0-rc.0.tgz#a409088732dd20aafb008f68d1d15e37b9c26329"
-  integrity sha512-Q1YbFz4PXvD9YVxE4/YQXtEw0OLg53sLr9dsquAnGMtt99hiOTF9xTr4Z2GjF7pTaU6KA1DHLoyh6Nng+d6N3g==
+react-reconciler@0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.0.tgz#053ae2fd1607e38a960e7a694ad694732e4989b6"
+  integrity sha512-n2FJE9vPSiZ0Dn/jaV/iOAO6rXepnk74QGRcgwPSgmN/2syUJnbfEz7Bw5yodBfJhjA3L7cu1YdImYISTj4KZQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "0.20.0-rc.0"
+    scheduler "^0.20.0"
 
-react-three-fiber@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-5.0.0.tgz#d519505024c883db2dc8d1b90a98a49aa95aefa2"
-  integrity sha512-EHqmljYhbtKl1ZXgoYzhwTDyJRRn2X2w4DTdINwI6+w5Jei5aiRSYp3avoDDKafEBmb/uDt2xejY3wQ1GfhFCQ==
+react-three-fiber@^5.0.1:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-5.1.4.tgz#ab156ceb629ae89031176a047f46af76512b308f"
+  integrity sha512-ReKiKwKKOOfL0OVljOvyWHlQ8t2yV9OffyBDvBqxq2F8gHCe/cTE+PMFRY8z60HK+5olX+177fTh0PqR74rBAw==
   dependencies:
-    "@babel/runtime" "^7.11.2"
+    "@babel/runtime" "^7.12.1"
     "@juggle/resize-observer" "^3.2.0"
     react-merge-refs "^1.1.0"
-    react-reconciler "0.26.0-rc.0"
-    react-use-measure "^2.0.1"
+    react-reconciler "0.26.0"
+    react-use-measure "^2.0.2"
     resize-observer-polyfill "^1.5.1"
-    scheduler "0.20.0-rc.0"
+    scheduler "0.20.0"
     tiny-emitter "^2.1.0"
-    use-asset "^0.1.1"
+    use-asset "^0.1.2"
     utility-types "^3.10.0"
 
-react-use-measure@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"
-  integrity sha512-lFfHiqcXbJ2/6aUkZwt8g5YYM7EGqNVxJhMqMPqv1BVXRKp8D7jYLlmma0SvhRY4WYxxkZpCdbJvhDylb5gcEA==
+react-use-measure@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.2.tgz#06b4f99b887d5dfcd7b7167a2da063d97ec8f62f"
+  integrity sha512-/+eSmQiU2ePNTwFCXX4JPrQNMvyu3sWrSDi/n5F6IMXwboB46IvtU8VHvG7Nc+egvtM7sBJKwmUx/vx6KIRDog==
   dependencies:
     debounce "^1.2.0"
 
@@ -5944,10 +5944,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@0.20.0-rc.0:
-  version "0.20.0-rc.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.0-rc.0.tgz#9cb397f88f9decea28d159d3aad068b54a6f35e4"
-  integrity sha512-5CZiVhk9xI9VmqaodZH+eO3aKgqYwjZ8uf9lnfRlYEwaB4lbmIq0mzuNY5w52sbPlZP9pifXQaLGudKHMgQZcw==
+scheduler@0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.0.tgz#3ff543696b169613afadb09d3fb3fe998d234dd2"
+  integrity sha512-XegIgta1bIaz2LdaL6eg1GEcE42g0BY9qFXCqlZ/+s2MuEKfigFCW6DEGBlZzeVFlwDmVusrWEyFtBo4sbkkdA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -5956,6 +5956,14 @@ scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.20.0:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
+  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -6761,10 +6769,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-asset@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/use-asset/-/use-asset-0.1.1.tgz#cc6835c36ee1b9cc79708d4c8fa954a62d55bc1c"
-  integrity sha512-HSBywtDxITn7xxc3AK3phkhtaD05w1X/9sjnIfrQcDPRCVpgJ2Z+Bg1ixK5PB3c81nuAuTXRgMGzRvGoztdDlg==
+use-asset@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/use-asset/-/use-asset-0.1.2.tgz#ec32e6f212d772e1e4873991d7a6ec326a7a44eb"
+  integrity sha512-hXnxOm5nDtxN5KPL5PUhEXbNsL9z8xIkYXo4WSBzV2dfS9ahaL6K+P/oMOUUiJ0FfyD1+N5EL8LhwVPUE6xHWA==
   dependencies:
     fast-deep-equal "^3.1.3"
 


### PR DESCRIPTION
## useTimerSelect Hook.

The `useTimerSelect` was built to aid with selection on a phone VR environment where controllers are not available. 

returns the percentage to completition:          <img src="http://latex.codecogs.com/svg.latex?&space;Tp&space;=&space;\frac{currentTimeLeft}{(timerTime)(1000)}\succ&space;" title="http://latex.codecogs.com/svg.latex? Tp = \frac{currentTimeLeft}{(timerTime)(1000)} " />
> percentage is from 0 --> 1, can be used to create an animation that displays that "select mode" is active while looking at object

### useTimerSelect arguments
- **Callback function**
-- Function that executes once the time constraint is met
- **Hover data object**
```js 
{
status: false // hover status of the "button", 
startTime : Date.now()  // start time of the hover 
}
```
- **Time Constraint** `seconds
-- number of seconds it takes the call back function to fire 

## Example use Case 

[CodeSandBox](https://codesandbox.io/s/usetimerselect-hook-example-96zhw?file=/src/example.js)
> When in a phone VR look at the 'look at me box' for 3 seconds to activate it. When controllers are available same will happen when using controller to hover over the box. I am planning on detecting if is running in phones so it only works on phone environments

```js 
const [hoverData, setHoverData] = useState( {status: false, startTime: Date.now() } ) 
// startTime is set to `Date.now()`when hover starts

const TimerPercentage = useTimerSelect( ( ) => console.log(fire), hoverData, 3 )
// If hoverData.status is true and the time constraint has passed (3 seconds); the callback function fires

```
### Planning to add 
- Phone enviroment detection so it doesn't run when controllers are available
- delay of x miliseconds to start conting towards select 
- refactor and test different improvements 
- check performance related stuff