### PR TITLE
[docs] fixed camera parenting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,32 @@ const mesh = useRef()
 const { gl, camera } = useThree()
 
 useEffect(() => {
-  const cam = gl.xr.isPresenting ? gl.xr.getCamera(camera) : camera
-  mesh.current.add(cam)
-  return () => mesh.current.remove(cam)
-}, [gl.xr.isPresenting, gl.xr, camera, mesh])
+  const cam = gl.xr.isPresenting ? gl.xr.getCamera(camera) : camera;
+  const parent = mesh.current;
+  if (parent) {
+    parent.add(cam);
+
+    return () => { 
+      parent.remove(cam)
+    };
+  }
+}, [gl.xr, camera, mesh]);
 
 // bundle add the controllers to the same object as the camera so it all stays together.
-const { controllers } = useXR()
+const { controllers } = useXR();
 useEffect(() => {
-  if (controllers.length > 0) controllers.forEach((c) => mesh.current.add(c.grip))
-  return () => controllers.forEach((c) => mesh.current.remove(c.grip))
-}, [controllers, mesh])
+  const parent = mesh.current;
+  if (parent) {
+    if (controllers.length > 0) {
+      controllers.forEach((c) => parent.add(c.grip));
+    }
+
+    return () => controllers.forEach((c) => parent.remove(c.grip))
+  }
+}, [controllers, mesh]);
+
+return <mesh ref={mesh} position={[0, 0, 10]}>
+    <boxBufferGeometry args={[1, 1, 1]} />
+    <meshStandardMaterial />
+</mesh>;
 ```


### PR DESCRIPTION
This fixes a few linting errors I was getting when using the code (with typescript), but more importantly fixes the camera position, ensuring it correctly positions itself relative to its parented object.

**Camera Position Issue**
When the parent object is positioned at `0, 0, 10` I would expect the camera to also be positioned at `0, 0, 10` once parented. However, the camera position was always static at `0, 0, 0`.

This seemed to be caused by `gl.xr.isPresenting` being present in the `useEffect` dependencies. I'm not sure why this was causing the issue - keen to know if anyone has any ideas. It seemed as though react wasn't detecting or registering any change in its value after it switched to true, but that's as far as I could get with it.

**Other minor fixes**
* Assigned the `parent` const due to warning: 
> "The ref value 'mesh.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'mesh.current' to a variable inside the effect, and use that variable in the cleanup function."
* Wrapped in `if (parent)` due to typescript error: 
> "Object is possibly 'undefined'." on `mesh.current`.
* Expanded the return function from the camera useEffect to ensure it doesn't return anything. The `parent.remove()` function returns a `Mesh` which makes typescript unhappy.