### PR TITLE
Moved responsibility of XR initialisation to react-xr

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@react-three/cannon": "https://github.com/pmndrs/use-cannon.git",
     "@react-three/drei": "^4.0.3",
-    "@react-three/fiber": "^6.0.6",
+    "@react-three/fiber": "^6.0.8",
     "@testing-library/jest-dom": "^5.3.0",
     "@testing-library/react": "^10.0.2",
     "@testing-library/user-event": "^10.0.1",
@@ -60,9 +60,9 @@
     "react-three-gui": "^0.1.5",
     "react-use-gesture": "^7.0.9",
     "styled-components": "^5.0.1",
-    "three": "^0.126.1",
+    "three": "^0.127.0",
     "threejs-meshline": "^2.0.10",
-    "zustand": "^2.2.3"
+    "zustand": "^3.3.3"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.9.0",

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -1,23 +1,8 @@
 import ReactDOM from 'react-dom'
-import React, { useState, useEffect, useRef, Suspense, useMemo, useCallback } from 'react'
-import {
-  useXREvent,
-  DefaultXRControllers,
-  Hands,
-  Select,
-  Hover,
-  useXR,
-  XR,
-  Interactive,
-  InteractionManager,
-  RayGrab,
-  useHitTest,
-  enableXR,
-} from '@react-three/xr'
-// import { OrbitControls, Sky, Text, Plane, Box } from '@react-three/drei'
-import { Box, Sky, Text } from '@react-three/drei'
-import { Canvas, useFrame, useThree } from '@react-three/fiber'
-import { Group } from 'three'
+import React, { useState, useRef } from 'react'
+import { DefaultXRControllers, useXR, XR, Interactive, useHitTest, enableXR } from '@react-three/xr'
+import { Box } from '@react-three/drei'
+import { Canvas, useFrame } from '@react-three/fiber'
 
 function Button(props) {
   const [hover, setHover] = useState(false)
@@ -58,20 +43,33 @@ function HitTestExample() {
   return <Box ref={ref} args={[0.1, 0.1, 0.1]} />
 }
 
-function App() {
+function ARExample() {
   return (
     <Canvas frameloop="never" onCreated={({ gl }) => enableXR(gl)}>
-      <XR arButton={true} sessionInit={{ requiredFeatures: ['hit-test'] }}>
-        <InteractionManager>
-          <ambientLight intensity={0.5} />
-          <pointLight position={[5, 5, 5]} />
-          {/* <Button position={[0, 0.8, -1]} /> */}
-          <DefaultXRControllers />
-          {/* <HitTestExample /> */}
-        </InteractionManager>
+      <XR buttonAR={true} sessionInit={{ requiredFeatures: ['hit-test'] }}>
+        <ambientLight intensity={0.5} />
+        <pointLight position={[5, 5, 5]} />
+        <HitTestExample />
       </XR>
     </Canvas>
   )
+}
+
+function VRExample() {
+  return (
+    <Canvas frameloop="never" onCreated={({ gl }) => enableXR(gl)}>
+      <XR buttonVR={true}>
+        <ambientLight intensity={0.5} />
+        <pointLight position={[5, 5, 5]} />
+        <Button position={[0, 0.8, -1]} />
+        <DefaultXRControllers />
+      </XR>
+    </Canvas>
+  )
+}
+
+function App() {
+  return <ARExample />
 }
 
 ReactDOM.render(<App />, document.querySelector('#root'))

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -1,21 +1,22 @@
 import ReactDOM from 'react-dom'
 import React, { useState, useEffect, useRef, Suspense, useMemo, useCallback } from 'react'
 import {
-  VRCanvas,
   useXREvent,
   DefaultXRControllers,
   Hands,
   Select,
   Hover,
   useXR,
+  XR,
   Interactive,
+  InteractionManager,
   RayGrab,
   useHitTest,
-  ARCanvas,
+  enableXR,
 } from '@react-three/xr'
 // import { OrbitControls, Sky, Text, Plane, Box } from '@react-three/drei'
 import { Box, Sky, Text } from '@react-three/drei'
-import { useFrame, useThree } from '@react-three/fiber'
+import { Canvas, useFrame, useThree } from '@react-three/fiber'
 import { Group } from 'three'
 
 function Button(props) {
@@ -59,14 +60,17 @@ function HitTestExample() {
 
 function App() {
   return (
-    <VRCanvas>
-      <ambientLight intensity={0.5} />
-      <pointLight position={[5, 5, 5]} />
-
-      <Button position={[0, 0.8, -1]} />
-      <DefaultXRControllers />
-      {/* <HitTestExample /> */}
-    </VRCanvas>
+    <Canvas frameloop="never" onCreated={({ gl }) => enableXR(gl)}>
+      <XR arButton={true} sessionInit={{ requiredFeatures: ['hit-test'] }}>
+        <InteractionManager>
+          <ambientLight intensity={0.5} />
+          <pointLight position={[5, 5, 5]} />
+          {/* <Button position={[0, 0.8, -1]} /> */}
+          <DefaultXRControllers />
+          {/* <HitTestExample /> */}
+        </InteractionManager>
+      </XR>
+    </Canvas>
   )
 }
 

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -1,6 +1,6 @@
 import ReactDOM from 'react-dom'
 import React, { useState, useRef } from 'react'
-import { DefaultXRControllers, useXR, XR, Interactive, useHitTest, enableXR } from '@react-three/xr'
+import { DefaultXRControllers, useXR, XR, Interactive, useHitTest, startXRloop } from '@react-three/xr'
 import { Box } from '@react-three/drei'
 import { Canvas, useFrame } from '@react-three/fiber'
 
@@ -45,7 +45,7 @@ function HitTestExample() {
 
 function ARExample() {
   return (
-    <Canvas frameloop="never" onCreated={({ gl }) => enableXR(gl)}>
+    <Canvas frameloop="never" onCreated={({ gl }) => startXRloop(gl)}>
       <XR buttonAR={true} sessionInit={{ requiredFeatures: ['hit-test'] }}>
         <ambientLight intensity={0.5} />
         <pointLight position={[5, 5, 5]} />
@@ -57,7 +57,7 @@ function ARExample() {
 
 function VRExample() {
   return (
-    <Canvas frameloop="never" onCreated={({ gl }) => enableXR(gl)}>
+    <Canvas frameloop="never" onCreated={({ gl }) => startXRloop(gl)}>
       <XR buttonVR={true}>
         <ambientLight intensity={0.5} />
         <pointLight position={[5, 5, 5]} />

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -2199,10 +2199,10 @@
     utility-types "^3.10.0"
     zustand "^3.0.3"
 
-"@react-three/fiber@^6.0.6":
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-6.0.6.tgz#ed0037d352502826ea14a854aa9f95ba6ba2e9c1"
-  integrity sha512-H8e0xQheE1ORPJisnybPVHHOQ8ebetAvJ9dGiLScVy2YyKbUdhQTNxFfHhXquRpM/OkYZoNA8mFxzGBiDCcarA==
+"@react-three/fiber@^6.0.8":
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-6.0.8.tgz#09e65c1f7a09395a9f2705734c5a61389ecb1820"
+  integrity sha512-squFicN1nal2uN4YuntYQQsg9yjwJIiY4Xv08crlkwR7wA8idX3dWCXYnExFc9zLZPQTCJ8wCHzLHus4f8lMCg==
   dependencies:
     "@babel/runtime" "^7.13.10"
     react-merge-refs "^1.1.0"
@@ -12231,10 +12231,10 @@ three-stdlib@^1.1.4:
     opentype.js "^1.3.3"
     zstddec "^0.0.2"
 
-three@^0.126.1:
-  version "0.126.1"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.126.1.tgz#cf4e4e52060fd952f6f0d5440cbd422c66bc4be7"
-  integrity sha512-eOEXnZeE1FDV0XgL1u08auIP13jxdN9LQBAEmlErYzMxtIIfuGIAZbijOyookALUhqVzVOx0Tywj6n192VM+nQ==
+three@^0.127.0:
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.127.0.tgz#c463f4d41b2c735dcf8e9e51a388815e80cd3791"
+  integrity sha512-wtgrn+mhYUbobxT7QN3GPdu3SRpSBQvwY6uOzLChWS7QE//f7paDU/+wlzbg+ngeIvBBqjBHSRuywTh8A99Jng==
 
 threejs-meshline@^2.0.10:
   version "2.0.10"
@@ -13272,11 +13272,6 @@ zstddec@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/zstddec/-/zstddec-0.0.2.tgz#57e2f28dd1ff56b750e07d158a43f0611ad9eeb4"
   integrity sha512-DCo0oxvcvOTGP/f5FA6tz2Z6wF+FIcEApSTu0zV5sQgn9hoT5lZ9YRAKUraxt9oP7l4e8TnNdi8IZTCX6WCkwA==
-
-zustand@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-2.2.3.tgz#07ee668bf600a5e0dcff8f8b60f35faa149f65d5"
-  integrity sha512-SSd5DzbwUN0b8ePW4I+8mSdXQc6UOqTgYzlMtoNvf7pogmFoXjeE0wZwCVopoZBnzz/uRBD2dsozzM2FXDQcXw==
 
 zustand@^3.0.3:
   version "3.1.3"

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "@babel/preset-env": "7.9.5",
     "@babel/preset-react": "7.9.4",
     "@babel/preset-typescript": "^7.9.0",
-    "@react-three/fiber": "^6.0.3",
+    "@react-three/fiber": "^6.0.8",
     "@types/jest": "^25.2.1",
     "@types/lodash-es": "^4.17.3",
     "@types/react": "^16.9.34",
     "@types/react-dom": "^16.9.6",
-    "@types/three": "^0.126.2",
+    "@types/three": "^0.127.0",
     "@typescript-eslint/eslint-plugin": "^2.29.0",
     "@typescript-eslint/parser": "^2.29.0",
     "babel-eslint": "^10.1.0",
@@ -74,7 +74,7 @@
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-size-snapshot": "^0.11.0",
-    "three": "^0.126.0",
+    "three": "^0.127.0",
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
@@ -83,7 +83,6 @@
     "react-dom": ">=16.13"
   },
   "dependencies": {
-    "react-merge-refs": "^1.1.0",
-    "three-stdlib": "^1.2.1"
+    "react-merge-refs": "^1.1.0"
   }
 }

--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -1,8 +1,8 @@
+import { XRControllerModelFactory } from 'three/examples/jsm/webxr/XRControllerModelFactory'
 import { useXR } from './XR'
 import React, { useEffect } from 'react'
 import { Color, Mesh, MeshBasicMaterial, BoxBufferGeometry, MeshBasicMaterialParameters, Group, Object3D, Intersection } from 'three'
 import { useFrame, useThree } from '@react-three/fiber'
-import { XRControllerModelFactory } from 'three-stdlib/webxr/XRControllerModelFactory'
 
 const modelFactory = new XRControllerModelFactory()
 const modelCache = new WeakMap<Group, any>()

--- a/src/Hands.tsx
+++ b/src/Hands.tsx
@@ -1,7 +1,7 @@
 import { useThree } from '@react-three/fiber'
 import { useEffect } from 'react'
-import { XRHandModelFactory } from 'three-stdlib/webxr/XRHandModelFactory'
-import { XRHandOculusMeshModelOptions } from 'three-stdlib/webxr/XRHandOculusMeshModel'
+import { XRHandModelFactory } from 'three/examples/jsm/webxr/XRHandModelFactory'
+import { XRHandOculusMeshModelOptions } from 'three/examples/jsm/webxr/XRHandOculusMeshModel'
 
 interface HandsProps {
   profile?: 'spheres' | 'boxes' | 'oculus' | 'oculus_lowpoly'
@@ -13,7 +13,7 @@ export function Hands({ profile = 'oculus' }: HandsProps) {
   useEffect(() => {
     const handFactory = new XRHandModelFactory().setPath('https://threejs.org/examples/models/fbx/')
 
-    const options = profile === 'oculus_lowpoly' ? ({ model: 'lowpoly' } as XRHandOculusMeshModelOptions) : undefined
+    const options = profile === 'oculus_lowpoly' ? { model: 'lowpoly' } as XRHandOculusMeshModelOptions : undefined
     const threeProfile = profile === 'oculus_lowpoly' ? 'oculus' : profile
 
     // @ts-ignore

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -92,7 +92,7 @@ export function useHitTest(hitTestCallback: (hitMatrix: Matrix4, hit: XRHitTestR
   })
 }
 
-export function enableXR(gl: WebGLRenderer) {
+export function startXRloop(gl: WebGLRenderer) {
   gl.xr.enabled = true
   gl.setAnimationLoop((timestamp) => advance(timestamp, true))
 }

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react'
-import { advance, Canvas, useFrame, useThree } from '@react-three/fiber'
+import { advance, useFrame, useThree } from '@react-three/fiber'
 import { ARButton } from 'three/examples/jsm/webxr/ARButton'
 import { VRButton } from 'three/examples/jsm/webxr/VRButton'
 import { XRController } from './XRController'
-import { Props as ContainerProps } from '@react-three/fiber/dist/declarations/src/web/Canvas'
 import { InteractionManager, InteractionsContext } from './Interactions'
 import { Group, Matrix4, WebGLRenderer, XRFrame, XRHandedness, XRHitTestResult, XRHitTestSource, XRReferenceSpace } from 'three'
 
@@ -100,12 +99,12 @@ export function enableXR(gl: WebGLRenderer) {
 
 interface XRProps {
   children: React.ReactNode;
-  vrButton?: boolean;
-  arButton?: boolean;
+  buttonVR?: boolean;
+  buttonAR?: boolean;
   sessionInit?: any;
 }
 
-export function XR({ children, vrButton, arButton, sessionInit }: XRProps) {
+export function XR({ children, buttonVR, buttonAR, sessionInit }: XRProps) {
   const { gl, camera } = useThree()
   const [isPresenting, setIsPresenting] = React.useState(() => gl.xr.isPresenting)
   const [player] = React.useState(() => new Group())
@@ -125,16 +124,18 @@ export function XR({ children, vrButton, arButton, sessionInit }: XRProps) {
   }, [gl])
 
   React.useEffect(() => {
-    if (vrButton) {
+    if (buttonVR) {
       const child = document.body.appendChild(VRButton.createButton(gl))
       return () => { document.body.removeChild(child); }
     }
+  }, [gl, buttonVR]);
 
-    if (arButton) {
+  React.useEffect(() => {
+    if (buttonAR) {
       const child = document.body.appendChild(ARButton.createButton(gl, sessionInit))
       return () => { document.body.removeChild(child); }
     }
-  }, [gl, vrButton, arButton, sessionInit])
+  }, [gl, buttonAR, sessionInit])
 
   const value = React.useMemo(() => ({ controllers, isPresenting, player }), [controllers, isPresenting, player])
 
@@ -143,7 +144,9 @@ export function XR({ children, vrButton, arButton, sessionInit }: XRProps) {
       <primitive object={player} dispose={null}>
         <primitive object={camera} dispose={null} />
       </primitive>
-      {children}
+      <InteractionManager>
+        {children}
+      </InteractionManager>
     </XRContext.Provider>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,10 +1131,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@react-three/fiber@^6.0.3":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-6.0.5.tgz#9f48977f1e4fc23d5a31e7c21615a3f00a1858cc"
-  integrity sha512-A7yiKB52ksMoiAgzoEZTICUHsuagiUzbVWnhrASG3tp54rXivV63Dc9iJ+mskI9OIZlMhHFf6IM1Em4E808HVw==
+"@react-three/fiber@^6.0.8":
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-6.0.8.tgz#09e65c1f7a09395a9f2705734c5a61389ecb1820"
+  integrity sha512-squFicN1nal2uN4YuntYQQsg9yjwJIiY4Xv08crlkwR7wA8idX3dWCXYnExFc9zLZPQTCJ8wCHzLHus4f8lMCg==
   dependencies:
     "@babel/runtime" "^7.13.10"
     react-merge-refs "^1.1.0"
@@ -1328,10 +1328,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/three@^0.126.2":
-  version "0.126.2"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.126.2.tgz#68838cc92cc89c156c05be63e54efc91f58a5417"
-  integrity sha512-6JqTgijtfXcTJik8NtiNxr2L90ex6ElM00qilOGeUcrEsJLOdzLJSIkXHUYS+KPAYQYtRJQKD6XaXds3HjS+gg==
+"@types/three@^0.127.0":
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.127.0.tgz#6d2bf6d7c14d4c4dc399a0e355085f27e996ac89"
+  integrity sha512-4Q33L6PzzxCXm0VdUv4x1/4VBnwWgCS7Ui6WpRh88GVIUUYsg5qU2GVzva14hDJbtfyNBxey7UcdInR4RkKPeQ==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -1532,16 +1532,6 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
-
-"@webgpu/glslang@^0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@webgpu/glslang/-/glslang-0.0.15.tgz#f5ccaf6015241e6175f4b90906b053f88483d1f2"
-  integrity sha512-niT+Prh3Aff8Uf1MVBVUsaNjFj9rJAKDXuoHIKiQbB+6IUP/3J3JIhBNyZ7lDhytvXxw6ppgnwKZdDJ08UMj4Q==
-
-"@webxr-input-profiles/motion-controllers@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@webxr-input-profiles/motion-controllers/-/motion-controllers-1.0.0.tgz#0a84533288af39d85bfe1987721035925d69be47"
-  integrity sha512-Ppxde+G1/QZbU8ShCQg+eq5VtlcL/FPkerF1dkDOLlIml0LJD1tFqnCZYR0SrHzYleIQ2siRnOx7xbFLaCpExQ==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -2182,13 +2172,6 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
-chevrotain@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-7.1.2.tgz#40e634c0b74fcb552118bf67f42f5820b84881fd"
-  integrity sha512-9bQsXVQ7UAvzMs7iUBBJ9Yv//exOy7bIR3PByOEk4M64vIE/LsiOiX7VIkMF/vEMlrSStwsaE884Bp9CpjtC5g==
-  dependencies:
-    regexp-to-ast "0.5.0"
 
 chokidar@^2.1.8:
   version "2.1.8"
@@ -3157,11 +3140,6 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
-
-fflate@^0.6.4:
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.6.9.tgz#fb369b30792a03ff7274e174f3b36e51292d3f99"
-  integrity sha512-hmAdxNHub7fw36hX7BHiuAO0uekp6ufY2sjxBXWxIf0sw5p7tnS9GVrdM4D12SDYQUHVpiC50fPBYPTjOzRU2Q==
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -4485,11 +4463,6 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-ktx-parse@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/ktx-parse/-/ktx-parse-0.0.5.tgz#3ede5b0fa691c0e68ac31c0da183609af1089757"
-  integrity sha512-fEUns44kq6iwUcX+yrfAZrXj9diDsbYpAw4fdG6Kq9Acf/xEn7VetnatcGIB4ZoFUiAzNY6fi7Z2DzqepjomNg==
-
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -4768,11 +4741,6 @@ mkdirp@^0.5.1, mkdirp@^0.5.3:
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mmd-parser@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mmd-parser/-/mmd-parser-1.0.4.tgz#87cc05782cb5974ca854f0303fc5147bc9d690e7"
-  integrity sha512-Qi0VCU46t2IwfGv5KF0+D/t9cizcDug7qnNoy9Ggk7aucp0tssV8IwTMkBlDbm+VqAf3cdQHTCARKSsuS2MYFg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -5058,14 +5026,6 @@ opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
   integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
-
-opentype.js@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/opentype.js/-/opentype.js-1.3.3.tgz#65b8645b090a1ad444065b784d442fa19d1061f6"
-  integrity sha512-/qIY/+WnKGlPIIPhbeNjynfD2PO15G9lA/xqlX2bDH+4lc3Xz5GCQ68mqxj3DdUv6AJqCeaPvuAoH8mVL0zcuA==
-  dependencies:
-    string.prototype.codepointat "^0.2.1"
-    tiny-inflate "^1.0.3"
 
 optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
@@ -5664,11 +5624,6 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
-
-regexp-to-ast@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz#56c73856bee5e1fef7f73a00f1473452ab712a24"
-  integrity sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==
 
 regexp.prototype.flags@^1.3.0:
   version "1.3.0"
@@ -6358,11 +6313,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string.prototype.codepointat@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz#004ad44c8afc727527b108cd462b4d971cd469bc"
-  integrity sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==
-
 string.prototype.matchall@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz#48bb510326fb9fdeb6a33ceaa81a6ea04ef7648e"
@@ -6550,25 +6500,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three-stdlib@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-1.2.1.tgz#7f88c1fd76846a0bab78389f9786c7447134d3a0"
-  integrity sha512-xLkCWx7Skp+tXa7GkK5vfK14vO5xmoZwVV63E/zebx87EdsBq+tXZKcFF2HCmUAIUl1tnvV3Yopc4eEBojzJNg==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@webgpu/glslang" "^0.0.15"
-    "@webxr-input-profiles/motion-controllers" "^1.0.0"
-    chevrotain "^7.1.2"
-    fflate "^0.6.4"
-    ktx-parse "^0.0.5"
-    mmd-parser "^1.0.3"
-    opentype.js "^1.3.3"
-    zstddec "^0.0.2"
-
-three@^0.126.0:
-  version "0.126.1"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.126.1.tgz#cf4e4e52060fd952f6f0d5440cbd422c66bc4be7"
-  integrity sha512-eOEXnZeE1FDV0XgL1u08auIP13jxdN9LQBAEmlErYzMxtIIfuGIAZbijOyookALUhqVzVOx0Tywj6n192VM+nQ==
+three@^0.127.0:
+  version "0.127.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.127.0.tgz#c463f4d41b2c735dcf8e9e51a388815e80cd3791"
+  integrity sha512-wtgrn+mhYUbobxT7QN3GPdu3SRpSBQvwY6uOzLChWS7QE//f7paDU/+wlzbg+ngeIvBBqjBHSRuywTh8A99Jng==
 
 throat@^5.0.0:
   version "5.0.0"
@@ -6594,11 +6529,6 @@ timers-browserify@^2.0.4:
   integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
   dependencies:
     setimmediate "^1.0.4"
-
-tiny-inflate@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
-  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -7138,11 +7068,6 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
-
-zstddec@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/zstddec/-/zstddec-0.0.2.tgz#57e2f28dd1ff56b750e07d158a43f0611ad9eeb4"
-  integrity sha512-DCo0oxvcvOTGP/f5FA6tz2Z6wF+FIcEApSTu0zV5sQgn9hoT5lZ9YRAKUraxt9oP7l4e8TnNdi8IZTCX6WCkwA==
 
 zustand@^3.3.3:
   version "3.3.3"


### PR DESCRIPTION
The main update of this PR is that the initialisation of XR is handled by this package, through the `startXRloop` function.

The new API looks as follows:
```
import { Canvas } from '@react-three/fiber'
import { XR, startXRloop } from '@react-three/xr'

<Canvas frameloop="never" onCreated={({ gl }) => startXRloop(gl)}>
      <XR buttonAR={true} sessionInit={{ requiredFeatures: ['hit-test'] }}>
            ...
      </XR>
</Canvas>
```

Notes:
- The `frameloop="never"` is required to disable the default r3f frameloop. With the previous `vr={true}` prop the frameloop is disabled [by r3f itself](https://github.com/pmndrs/react-three-fiber/blob/c2a73ee8e720d0045ff825e784b16d715f101cdb/packages/fiber/src/core/loop.ts#L66), but this is implicit and confusing for the user who wishes to manipulate the frameloop. The `setAnimationLoop` we currently use starts an animation loop in threejs, and with the `startXRloop` function it is explicit that a new loop is started. It's a bit more code but I think it makes a whole lot more sense to the user. We could improve upon this api in the future, but right now I think it's nice to have the responsibility of XR initialisation taken away from r3f main package. (https://github.com/pmndrs/react-three-fiber/issues/1177)
- The `<XR>` component now has two new props `buttonAR` and `buttonVR` which you can set to `true` to render a standard threejs XR button. I can make an example later on how to render a custom button. `sessionInit` is also moved to this XR component.
- 

This PR includes other changes:
- Updated to the latest version of three, @react-three/fiber and zustand
- Moved dependency of three-stdlib back to three/jsm/examples. With the last update of threejs the console was flooded with warnings and this crashed the browser. There are recent changes in the dependencies that are not yet updated in three-stdlib, and it looks like the three webxr api is not yet very stable, so I would suggest to stick with direct threejs dependency for now.
- Updated example index to have a ARExample and VRExample component. (FYI I want to look into making a setup similar to https://github.com/pmndrs/leva, where the demos are separated and automatically deployed to codesandbox)