### PR TITLE
Adding hands to XRController

### DIFF
--- a/src/Hands.tsx
+++ b/src/Hands.tsx
@@ -1,21 +1,23 @@
 import { useThree } from '@react-three/fiber'
-import { OculusHandModel } from './webxr/OculusHandModel.js'
 import { useEffect } from 'react'
+
+import { OculusHandModel } from './webxr/OculusHandModel.js'
+import { useXR } from './XR'
 
 export function Hands() {
   const { scene, gl } = useThree()
+  const { controllers } = useXR()
 
   useEffect(() => {
-    // @ts-ignore
-    const hand1 = gl.xr.getHand(0)
-    hand1.add(new OculusHandModel(hand1))
-    scene.add(hand1)
+    controllers.forEach(({ hand, inputSource }) => {
+      if (hand.children.length === 0) {
+        hand.add(new OculusHandModel(hand))
 
-    // @ts-ignore
-    const hand2 = gl.xr.getHand(1)
-    hand1.add(new OculusHandModel(hand2))
-    scene.add(hand2)
-  }, [scene, gl])
+        // throwing fake event for the Oculus Hand Model so it starts loading
+        hand.dispatchEvent({ type: 'connected', data: inputSource, fake: true })
+      }
+    })
+  }, [scene, gl, controllers])
 
   return null
 }

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -127,7 +127,7 @@ export function XR(props: { children: React.ReactNode }) {
     session?.addEventListener('inputsourceschange', handleInputSourcesChange)
 
     return () => {
-      session?.addEventListener('inputsourceschange', handleInputSourcesChange)
+      session?.removeEventListener('inputsourceschange', handleInputSourcesChange)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPresenting])

--- a/src/XRController.tsx
+++ b/src/XRController.tsx
@@ -9,19 +9,24 @@ export interface XRController {
   grip: Group
   /** Group with orientation of the preferred pointing ray */
   controller: Group
+  /** Group with hand */
+  hand: Group
 }
 export const XRController = {
   make: (id: number, gl: WebGLRenderer, onConnected: (c: XRController) => any, onDisconnected: (c: XRController) => any) => {
     const controller = gl.xr.getController(id)
     const grip = gl.xr.getControllerGrip(id)
+    const hand = gl.xr.getHand(id)
 
     const xrController: XRController = {
       inputSource: undefined as any,
       grip,
-      controller
+      controller,
+      hand
     }
     grip.userData.name = 'grip'
     controller.userData.name = 'controller'
+    controller.userData.name = 'hand'
 
     controller.addEventListener('connected', (event) => {
       if (event.fake) {

--- a/src/XRController.tsx
+++ b/src/XRController.tsx
@@ -26,7 +26,7 @@ export const XRController = {
     }
     grip.userData.name = 'grip'
     controller.userData.name = 'controller'
-    controller.userData.name = 'hand'
+    hand.userData.name = 'hand'
 
     controller.addEventListener('connected', (event) => {
       if (event.fake) {


### PR DESCRIPTION
- added hands to the players group
- added a handtracking flag to the XR context based on the `inputsourceschange` event

I've setup examples (for easier testing).

The regular hands test we already have, with the changes:
https://elated-stonebraker-702075.netlify.app/hands

Repo can be found here: (`npm install` / `yarn` will setup the package correctly with my branch)
https://github.com/driescroons/react-xr-hands

I've also been working on a DefaultHandControllers component where the hand models are always shown, even when using controllers. It still needs a bit of work (different "poses" based on a button click, ...) but you'll get the basic idea. Could that also be something that could be added to react-xr?
https://elated-stonebraker-702075.netlify.app/default-hand-controllers

Let me know if something needs to be changed / added!