### PR TITLE
refactor: allow sessionInit to be specified in VR

### DIFF
--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -150,9 +150,7 @@ export function XR(props: { children: React.ReactNode }) {
   )
 }
 
-export type XRCanvasProps = ContainerProps & { sessionInit?: XRSessionInit }
-
-function XRCanvas({ children, ...rest }: XRCanvasProps) {
+function XRCanvas({ children, ...rest }: ContainerProps) {
   return (
     <Canvas vr {...rest}>
       <XR>
@@ -161,6 +159,8 @@ function XRCanvas({ children, ...rest }: XRCanvasProps) {
     </Canvas>
   )
 }
+
+export type XRCanvasProps = ContainerProps & { sessionInit?: XRSessionInit }
 
 export function VRCanvas({ children, sessionInit, ...rest }: XRCanvasProps) {
   return (

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -149,7 +149,9 @@ export function XR(props: { children: React.ReactNode }) {
   )
 }
 
-function XRCanvas({ children, ...rest }: ContainerProps) {
+export type XRCanvasProps = ContainerProps & { sessionInit?: any }
+
+function XRCanvas({ children, ...rest }: XRCanvasProps) {
   return (
     <Canvas vr {...rest}>
       <XR>
@@ -159,15 +161,15 @@ function XRCanvas({ children, ...rest }: ContainerProps) {
   )
 }
 
-export function VRCanvas({ children, ...rest }: ContainerProps) {
+export function VRCanvas({ children, sessionInit, ...rest }: XRCanvasProps) {
   return (
-    <XRCanvas onCreated={({ gl }) => void document.body.appendChild(VRButton.createButton(gl))} {...rest}>
+    <XRCanvas onCreated={({ gl }) => void document.body.appendChild(VRButton.createButton(gl, sessionInit))} {...rest}>
       {children}
     </XRCanvas>
   )
 }
 
-export function ARCanvas({ children, sessionInit, ...rest }: ContainerProps & { sessionInit?: any }) {
+export function ARCanvas({ children, sessionInit, ...rest }: XRCanvasProps) {
   return (
     <XRCanvas onCreated={({ gl }) => void document.body.appendChild(ARButton.createButton(gl, sessionInit))} {...rest}>
       {children}

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -6,6 +6,7 @@ import { ARButton } from './webxr/ARButton'
 import { VRButton } from './webxr/VRButton'
 import { XRController } from './XRController'
 import { Props as ContainerProps } from '@react-three/fiber/dist/declarations/src/web/Canvas'
+import { XRSessionInit } from 'three'
 import { InteractionManager, InteractionsContext } from './Interactions'
 import { Group, Matrix4, XRFrame, XRHandedness, XRHitTestResult, XRHitTestSource, XRInputSourceChangeEvent, XRReferenceSpace } from 'three'
 
@@ -149,7 +150,7 @@ export function XR(props: { children: React.ReactNode }) {
   )
 }
 
-export type XRCanvasProps = ContainerProps & { sessionInit?: any }
+export type XRCanvasProps = ContainerProps & { sessionInit?: XRSessionInit }
 
 function XRCanvas({ children, ...rest }: XRCanvasProps) {
   return (

--- a/src/webxr/VRButton.js
+++ b/src/webxr/VRButton.js
@@ -1,11 +1,10 @@
 class VRButton {
-  static createButton(renderer, options) {
-    if (options) {
-      console.error(
-        'THREE.VRButton: The "options" parameter has been removed. Please set the reference space type via renderer.xr.setReferenceSpaceType() instead.'
-      )
+  static createButton(
+    renderer,
+    sessionInit = {
+      optionalFeatures: ['local-floor', 'bounded-floor', 'hand-tracking']
     }
-
+  ) {
     const button = document.createElement('button')
 
     function showEnterVR(/*device*/) {
@@ -55,9 +54,6 @@ class VRButton {
           // ('local' is always available for immersive sessions and doesn't need to
           // be requested separately.)
 
-          const sessionInit = {
-            optionalFeatures: ['local-floor', 'bounded-floor', 'hand-tracking']
-          }
           navigator.xr.requestSession('immersive-vr', sessionInit).then(onSessionStarted)
         } else {
           currentSession.end()

--- a/src/webxr/VRButton.js
+++ b/src/webxr/VRButton.js
@@ -1,10 +1,5 @@
 class VRButton {
-  static createButton(
-    renderer,
-    sessionInit = {
-      optionalFeatures: ['local-floor', 'bounded-floor', 'hand-tracking']
-    }
-  ) {
+  static createButton(renderer, sessionInit = {}) {
     const button = document.createElement('button')
 
     function showEnterVR(/*device*/) {
@@ -54,7 +49,11 @@ class VRButton {
           // ('local' is always available for immersive sessions and doesn't need to
           // be requested separately.)
 
-          navigator.xr.requestSession('immersive-vr', sessionInit).then(onSessionStarted)
+          const optionalFeatures = [sessionInit.optionalFeatures, 'local-floor', 'bounded-floor', 'hand-tracking'].flat().filter(Boolean)
+
+          sessionInit.optionalFeatures = navigator.xr
+            .requestSession('immersive-vr', { ...sessionInit, optionalFeatures })
+            .then(onSessionStarted)
         } else {
           currentSession.end()
         }


### PR DESCRIPTION
Fixes #67 by refactoring `VRButton` to accept `sessionInit` as an argument like `ARButton`.