### PR TITLE
fix: HandModel not being instantiated in some cases

### DIFF
--- a/src/Hands.tsx
+++ b/src/Hands.tsx
@@ -13,7 +13,8 @@ export function Hands(props: {
 
   useEffect(() => {
     controllers.forEach(({ hand, inputSource }) => {
-      if (hand.children.length === 0) {
+      const handModel = hand.children.find(child => child instanceof HandModel)
+      if (handModel === undefined) {
         hand.add(new HandModel(hand,[props.modelLeft,props.modelRight]))
 
         // throwing fake event for the Oculus Hand Model so it starts loading


### PR DESCRIPTION
Hi there,

There is currently an issue where the HandModels are not being instantiated in some cases.

Here is a live demo to try with Oculus Browser:
https://codesandbox.io/s/react-xr-hands-demo-forked-uojb4

The reason is that `gl.xr.getHand` (called [here](https://github.com/pmndrs/react-xr/blob/449befa1e9e255bd7c12f03426f479b10a0381f0/src/XRController.tsx#L19)) has an inconsistent number of `children` (either 0 or 25), seemingly related to the amount of content in the scene (perhaps a race condition outside of the scope of this repo).

The problem is that the `HandModel` is instantiated only if the length of `children` is zero:
https://github.com/pmndrs/react-xr/blob/80971fbb88dd9846957af274750431de77ea83c0/src/Hands.tsx#L16

Instead, this fix proposes to check for an instance of `HandModel` in `children` and instantiates it if missing.







