### PR TITLE
fix(#93) entering vr will not overwrite the xr session feature list anymore

### DIFF
--- a/src/webxr/VRButton.js
+++ b/src/webxr/VRButton.js
@@ -51,9 +51,7 @@ class VRButton {
 
           const optionalFeatures = [sessionInit.optionalFeatures, 'local-floor', 'bounded-floor', 'hand-tracking'].flat().filter(Boolean)
 
-          sessionInit.optionalFeatures = navigator.xr
-            .requestSession('immersive-vr', { ...sessionInit, optionalFeatures })
-            .then(onSessionStarted)
+          navigator.xr.requestSession('immersive-vr', { ...sessionInit, optionalFeatures }).then(onSessionStarted)
         } else {
           currentSession.end()
         }


### PR DESCRIPTION
Fixes issue #93 

As described in the proposed solution in the issue, the unnecessary assignment has been deleted