### PR TITLE
feat(XRIntersectionEvent): filter event candidates via state.raycaster or stop on first hit

### DIFF
--- a/src/Interactions.tsx
+++ b/src/Interactions.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, ReactNode, useMemo, useContext, forwardRef } from 'react'
 import { useXR } from './XR'
-import { Object3D, Group, Matrix4, Raycaster, Intersection, XRHandedness } from 'three'
+import { Object3D, Group, Matrix4, Intersection, XRHandedness } from 'three'
 import { useThree, useFrame } from '@react-three/fiber'
 import { XRController } from './XRController'
 import { ObjectsState } from './ObjectsState'
@@ -102,9 +102,7 @@ export function InteractionManager({ children }: { children: any }) {
 
         while (eventObject) {
           if (ObjectsState.has(interactions, eventObject, 'onHover') && !hovering.has(eventObject)) {
-            ObjectsState.get(interactions, eventObject, 'onHover')?.forEach((handler) => {
-              handler({ controller: it, intersection })
-            })
+            ObjectsState.get(interactions, eventObject, 'onHover')?.forEach((handler) => handler({ controller: it, intersection }))
           }
 
           hovering.set(eventObject, intersection)
@@ -127,9 +125,9 @@ export function InteractionManager({ children }: { children: any }) {
   const triggerEvent = (interaction: XRInteractionType) => (e: XREvent) => {
     const hovering = hoverState[e.controller.inputSource.handedness]
     for (const hovered of hovering.keys()) {
-      ObjectsState.get(interactions, hovered, interaction)?.forEach((handler) => {
+      ObjectsState.get(interactions, hovered, interaction)?.forEach((handler) =>
         handler({ controller: e.controller, intersection: hovering.get(hovered) })
-      })
+      )
     }
   }
 

--- a/src/Interactions.tsx
+++ b/src/Interactions.tsx
@@ -87,19 +87,22 @@ export function InteractionManager({ children }: { children: any }) {
       const hits = new Set()
       const intersections = intersect(controller)
 
-      intersections.forEach((intersection) => {
+      const intersection = intersections.find((i) => i?.object)
+      if (intersection) {
         let eventObject: Object3D | null = intersection.object
 
         while (eventObject) {
           if (ObjectsState.has(interactions, eventObject, 'onHover') && !hovering.has(eventObject)) {
-            ObjectsState.get(interactions, eventObject, 'onHover')?.forEach((handler) => handler({ controller: it, intersection }))
+            ObjectsState.get(interactions, eventObject, 'onHover')?.forEach((handler) => {
+              handler({ controller: it, intersection })
+            })
           }
 
           hovering.set(eventObject, intersection)
           hits.add(eventObject.id)
           eventObject = eventObject.parent
         }
-      })
+      }
 
       // Trigger blur on all the object that were hovered in the previous frame
       // but missed in this one
@@ -115,9 +118,9 @@ export function InteractionManager({ children }: { children: any }) {
   const triggerEvent = (interaction: XRInteractionType) => (e: XREvent) => {
     const hovering = hoverState[e.controller.inputSource.handedness]
     for (const hovered of hovering.keys()) {
-      ObjectsState.get(interactions, hovered, interaction)?.forEach((handler) =>
+      ObjectsState.get(interactions, hovered, interaction)?.forEach((handler) => {
         handler({ controller: e.controller, intersection: hovering.get(hovered) })
-      )
+      })
     }
   }
 


### PR DESCRIPTION
Fixes #97 by filtering event candidates, stopping at the first by default.

You can control this filtering via `state.raycaster.filter` as you can with R3F's built-in events.