### PR TITLE
chore(useXRFrame): add deprecation notice for v8

### DIFF
--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -235,6 +235,13 @@ export const useXR = () => {
   return contextValue
 }
 
+/**
+ * @deprecated R3F v8's built-in `useFrame` extends the `XRSession.requestAnimationFrame` signature:
+ *
+ * `useFrame((state, delta, xrFrame) => void)`
+ *
+ * @see https://mdn.io/XRFrame
+ */
 export const useXRFrame = (callback: (time: DOMHighResTimeStamp, xrFrame: XRFrame) => void) => {
   const { gl } = useThree()
   const requestRef = React.useRef<number>()


### PR DESCRIPTION
Follows up #114 by deprecating `useXRFrame` as it is natively implemented in R3F v8.