### PR TITLE
fix(webxr): import three-stdlib from flatbundle for cjs targets

### DIFF
--- a/src/webxr/XRControllerModelFactory.js
+++ b/src/webxr/XRControllerModelFactory.js
@@ -1,6 +1,6 @@
 import { Mesh, MeshBasicMaterial, Object3D, SphereGeometry } from 'three'
 import { MotionControllerConstants, fetchProfile, MotionController } from './XRMotionControllers'
-import { GLTFLoader } from 'three-stdlib/loaders/GLTFLoader'
+import { GLTFLoader } from 'three-stdlib'
 
 const DEFAULT_PROFILES_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets@1.0/dist/profiles'
 const DEFAULT_PROFILE = 'generic-trigger'

--- a/src/webxr/XRHandMeshModel.js
+++ b/src/webxr/XRHandMeshModel.js
@@ -1,4 +1,4 @@
-import { GLTFLoader } from 'three-stdlib/loaders/GLTFLoader'
+import { GLTFLoader } from 'three-stdlib'
 
 const DEFAULT_HAND_PROFILE_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets@1.0/dist/profiles/generic-hand/'
 


### PR DESCRIPTION
Fixes the follow-up issue in #118 where some webxr modules import the GLTFLoader module from three-stdlib instead of resolving to the CJS flatbundle.