### PR TITLE
Fix markdown demo links for github

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ npm install @react-three/xr
 
 ## Examples
 
-[<img width="100px" src="https://i.imgur.com/K71D3Ts.gif" alt=""></img>](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
+[<img src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
 
-[<img width="100px" src="https://i.imgur.com/5yh7LKz.gif" alt=""></img>](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
+[<img src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
 
-[<img width="100px" src="https://i.imgur.com/yuNwPpn.gif" alt=""></img>](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
+[<img src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
 
-[<img width="100px" src="https://i.imgur.com/T7WKFCO.gif" alt=""></img>](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
+[<img src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
 
-[<img width="100px" src="https://i.imgur.com/Cxes0Xj.gif" alt=""></img>](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
+[<img src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
 
 <p align="middle">
   <i>These demos are real, you can click them! They contain the full code, too.</i>

--- a/README.md
+++ b/README.md
@@ -12,15 +12,11 @@ npm install @react-three/xr
 
 ## Examples
 
-<p align="center">
-
-[<img height="150" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
-[<img height="150" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro)
-[<img height="150" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm)
-[<img height="150" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp)
-[<img height="150" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r)
-
-</p>
+[<img height="100px" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet) 
+[<img height="100px" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
+[<img height="100px" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
+[<img height="100px" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
+[<img height="100px" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
 
 <p align="middle">
   <i>These demos are real, you can click them! They contain the full code, too.</i>

--- a/README.md
+++ b/README.md
@@ -13,14 +13,10 @@ npm install @react-three/xr
 ## Examples
 
 [<img height="50px" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
-
-[<img height="50px" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
-
-[<img height="50px" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
-
-[<img height="50px" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
-
-[<img height="50px" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
+[<img height="50px" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro)
+[<img height="50px" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm)
+[<img height="50px" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp)
+[<img height="50px" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r)
 
 <p align="middle">
   <i>These demos are real, you can click them! They contain the full code, too.</i>

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ npm install @react-three/xr
 
 ## Examples
 
-[<img height="50px" src="https://i.imgur.com/K71D3Ts.gif" alt="" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
+[<img height="100px" src="https://i.imgur.com/K71D3Ts.gif" alt="" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
 
-[<img height="50px" src="https://i.imgur.com/5yh7LKz.gif" alt="" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
+[<img height="100px" src="https://i.imgur.com/5yh7LKz.gif" alt="" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
 
-[<img height="50px" src="https://i.imgur.com/yuNwPpn.gif" alt="" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
+[<img height="100px" src="https://i.imgur.com/yuNwPpn.gif" alt="" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
 
-[<img height="50px" src="https://i.imgur.com/T7WKFCO.gif" alt="" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
+[<img height="100px" src="https://i.imgur.com/T7WKFCO.gif" alt="" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
 
-[<img height="50px" src="https://i.imgur.com/Cxes0Xj.gif" alt="" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
+[<img height="100px" src="https://i.imgur.com/Cxes0Xj.gif" alt="" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
 
 <p align="middle">
   <i>These demos are real, you can click them! They contain the full code, too.</i>

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ npm install @react-three/xr
 
 ## Examples
 
-[<img height="99px" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
+[<img height="75px" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
 
-[<img height="99px" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
+[<img height="75px" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
 
-[<img height="99px" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
+[<img height="75px" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
 
-[<img height="99px" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
+[<img height="75px" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
 
-[<img height="99px" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
+[<img height="75px" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
 
 <p align="middle">
   <i>These demos are real, you can click them! They contain the full code, too.</i>

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ npm install @react-three/xr
 
 ## Examples
 
-[<img height="100px" src="https://i.imgur.com/K71D3Ts.gif" alt="" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
+[<img height="99px" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
 
-[<img height="100px" src="https://i.imgur.com/5yh7LKz.gif" alt="" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
+[<img height="99px" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
 
-[<img height="100px" src="https://i.imgur.com/yuNwPpn.gif" alt="" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
+[<img height="99px" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
 
-[<img height="100px" src="https://i.imgur.com/T7WKFCO.gif" alt="" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
+[<img height="99px" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
 
-[<img height="100px" src="https://i.imgur.com/Cxes0Xj.gif" alt="" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
+[<img height="99px" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
 
 <p align="middle">
   <i>These demos are real, you can click them! They contain the full code, too.</i>

--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ npm install @react-three/xr
 
 ## Examples
 
-[<img height="100px" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet) 
-[<img height="100px" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
-[<img height="100px" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
-[<img height="100px" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
-[<img height="100px" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
+[<img width="100px" src="https://i.imgur.com/K71D3Ts.gif" alt=""></img>](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
+
+[<img width="100px" src="https://i.imgur.com/5yh7LKz.gif" alt=""></img>](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
+
+[<img width="100px" src="https://i.imgur.com/yuNwPpn.gif" alt=""></img>](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
+
+[<img width="100px" src="https://i.imgur.com/T7WKFCO.gif" alt=""></img>](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
+
+[<img width="100px" src="https://i.imgur.com/Cxes0Xj.gif" alt=""></img>](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
 
 <p align="middle">
   <i>These demos are real, you can click them! They contain the full code, too.</i>

--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ React components and hooks for creating VR/AR applications with [@react-three/fi
 npm install @react-three/xr
 ```
 
+## Examples
+
 <p align="center">
-  <a href="https://codesandbox.io/s/react-xr-paddle-demo-v4uet"><img width="390" src="https://i.imgur.com/K71D3Ts.gif" /></a>
-  <a href="https://codesandbox.io/s/react-xr-simple-demo-8i9ro"><img width="390" src="https://i.imgur.com/5yh7LKz.gif" /></a>
-  <a href="https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm"><img height="221" src="https://i.imgur.com/yuNwPpn.gif" /></a>
-  <a href="https://codesandbox.io/s/react-xr-hands-demo-gczkp"><img height="221" src="https://i.imgur.com/T7WKFCO.gif" /></a>
-  <a href="https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r"><img height="221" src="https://i.imgur.com/Cxes0Xj.gif" /></a>
+
+[<img height="150" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
+[<img height="150" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro)
+[<img height="150" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm)
+[<img height="150" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp)
+[<img height="150" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r)
+
 </p>
 
 <p align="middle">

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ npm install @react-three/xr
 
 ## Examples
 
-[<img src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
+[<img height="50px" src="https://i.imgur.com/K71D3Ts.gif" alt="" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
 
-[<img src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
+[<img height="50px" src="https://i.imgur.com/5yh7LKz.gif" alt="" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
 
-[<img src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
+[<img height="50px" src="https://i.imgur.com/yuNwPpn.gif" alt="" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
 
-[<img src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
+[<img height="50px" src="https://i.imgur.com/T7WKFCO.gif" alt="" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
 
-[<img src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
+[<img height="50px" src="https://i.imgur.com/Cxes0Xj.gif" alt="" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
 
 <p align="middle">
   <i>These demos are real, you can click them! They contain the full code, too.</i>

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ npm install @react-three/xr
 
 ## Examples
 
-[<img height="75px" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
+[<img height="50px" src="https://i.imgur.com/K71D3Ts.gif" />](https://codesandbox.io/s/react-xr-paddle-demo-v4uet)
 
-[<img height="75px" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
+[<img height="50px" src="https://i.imgur.com/5yh7LKz.gif" />](https://codesandbox.io/s/react-xr-simple-demo-8i9ro) 
 
-[<img height="75px" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
+[<img height="50px" src="https://i.imgur.com/yuNwPpn.gif" />](https://codesandbox.io/s/react-xr-simple-ar-demo-8w8hm) 
 
-[<img height="75px" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
+[<img height="50px" src="https://i.imgur.com/T7WKFCO.gif" />](https://codesandbox.io/s/react-xr-hands-demo-gczkp) 
 
-[<img height="75px" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
+[<img height="50px" src="https://i.imgur.com/Cxes0Xj.gif" />](https://codesandbox.io/s/react-xr-hands-physics-demo-tp97r) 
 
 <p align="middle">
   <i>These demos are real, you can click them! They contain the full code, too.</i>


### PR DESCRIPTION
On github the readme markdown image links for demos are not working, this PR changes the <a /> links to markdown []() links