### PR TITLE
fix: downlevel transpile, use correct node exts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,11 @@
     "Michael Bashurov (https://github.com/saitonakamura)",
     "Cody Bennett (https://github.com/codyjasonbennett)"
   ],
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/*",
-    "src/*"
+    "dist/*"
   ],
   "sideEffects": false,
   "scripts": {

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,11 +18,11 @@ export default defineConfig({
     minify: false,
     outDir: path.resolve(process.cwd(), 'dist'),
     emptyOutDir: true,
-    target: 'esnext',
+    target: 'es2018',
     lib: {
       formats: ['es', 'cjs'],
       entry: path.resolve(process.cwd(), 'src/index.tsx'),
-      fileName: (format) => (format === 'cjs' ? 'index.cjs' : 'index.js')
+      fileName: (format) => (format === 'es' ? 'index.mjs' : 'index.js')
     },
     rollupOptions: {
       external: (id) => !id.startsWith('.') && !path.isAbsolute(id)


### PR DESCRIPTION
Transpiles to ES 2018 for Node compat and uses mjs/js exts (alternatively type=module and cjs) to enable proper Node resolution.