### PR TITLE
fix(HandModel): fix circular reference on dispose

### DIFF
--- a/src/webxr/HandModel.js
+++ b/src/webxr/HandModel.js
@@ -77,7 +77,21 @@ class HandModel extends Object3D {
 
   dispose() {
     this.clear()
-    if (this.motionController) this.motionController.dispose?.()
+    if (this.motionController) {
+      this.motionController.traverse((node) => {
+        if (!node) return
+
+        if (node.type !== 'Scene') {
+          node.dispose?.()
+
+          // Dispose of its properties as well
+          for (const property in node) {
+            if (property.dispose) property.dispose?.()
+            delete node[property]
+          }
+        }
+      })
+    }
     this.motionController = null
   }
 }

--- a/src/webxr/XRHandMeshModel.js
+++ b/src/webxr/XRHandMeshModel.js
@@ -89,20 +89,7 @@ class XRHandMeshModel {
   }
 
   dispose() {
-    this.handModel.traverse((node) => {
-      if (!node) return
-
-      if (node.type !== 'Scene') {
-        node.dispose?.()
-
-        // Dispose of its properties as well
-        for (const property in node) {
-          if (property.dispose) property.dispose?.()
-          delete node[property]
-        }
-      }
-    })
-
+    this.handModel = null
     this.bones = []
   }
 }


### PR DESCRIPTION
Prevents HandModel's children from recursively disposing its parent.