### PR TITLE
refactor: cleanup controllers on unmount, fix internal effect timings

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "three": ">=0.141"
   },
   "dependencies": {
-    "react-merge-refs": "^1.1.0",
     "three-stdlib": "^2.8.6"
   }
 }

--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -1,16 +1,17 @@
-import { useXR } from './XR'
-import React, { useEffect } from 'react'
-import type { MeshBasicMaterialParameters, Group, Object3D, Intersection } from 'three'
+import * as React from 'react'
+import * as THREE from 'three'
 import { Color, Mesh, MeshBasicMaterial, BoxBufferGeometry } from 'three'
 import { useFrame, useThree } from '@react-three/fiber'
+import { useXR } from './XR'
 import { XRControllerModelFactory } from './webxr/XRControllerModelFactory'
 
 const modelFactory = new XRControllerModelFactory()
-const modelCache = new WeakMap<Group, any>()
-export function DefaultXRControllers({ rayMaterial = {} }: { rayMaterial?: MeshBasicMaterialParameters }) {
-  const { scene } = useThree()
+const modelCache = new WeakMap<THREE.Group, any>()
+
+export function DefaultXRControllers({ rayMaterial = {} }: { rayMaterial?: THREE.MeshBasicMaterialParameters }) {
+  const scene = useThree((state) => state.scene)
   const { controllers, hoverState } = useXR()
-  const [rays] = React.useState(new Map<number, Mesh>())
+  const [rays] = React.useState(() => new Map<number, Mesh>())
 
   // Show ray line when hovering objects
   useFrame(() => {
@@ -18,7 +19,7 @@ export function DefaultXRControllers({ rayMaterial = {} }: { rayMaterial?: MeshB
       const ray = rays.get(it.controller.id)
       if (!ray) return
 
-      const intersection: Intersection = hoverState[it.inputSource.handedness].values().next().value
+      const intersection: THREE.Intersection = hoverState[it.inputSource.handedness].values().next().value
       if (!intersection || it.inputSource.handedness === 'none') {
         ray.visible = false
         return
@@ -35,12 +36,12 @@ export function DefaultXRControllers({ rayMaterial = {} }: { rayMaterial?: MeshB
     })
   })
 
-  useEffect(() => {
+  React.useLayoutEffect(() => {
     const cleanups: any[] = []
 
     controllers.forEach(({ controller, grip, inputSource }) => {
       // Attach 3D model of the controller
-      let model: Object3D
+      let model: THREE.Object3D
       if (modelCache.has(controller)) {
         model = modelCache.get(controller)
       } else {

--- a/src/Hands.tsx
+++ b/src/Hands.tsx
@@ -1,14 +1,14 @@
+import * as React from 'react'
 import { useThree } from '@react-three/fiber'
-import { useEffect } from 'react'
-
 import { HandModel } from './webxr/HandModel.js'
 import { useXR } from './XR'
 
 export function Hands(props: { modelLeft?: string; modelRight?: string }) {
-  const { scene, gl } = useThree()
+  const scene = useThree((state) => state.scene)
+  const gl = useThree((state) => state.gl)
   const { controllers } = useXR()
 
-  useEffect(() => {
+  React.useLayoutEffect(() => {
     controllers.forEach(({ hand, inputSource }) => {
       const handModel = hand.children.find((child) => child instanceof HandModel) as HandModel | undefined
       if (handModel) {

--- a/src/ObjectsState.tsx
+++ b/src/ObjectsState.tsx
@@ -1,4 +1,4 @@
-import type { Object3D } from 'three'
+import * as THREE from 'three'
 
 /**
  * Store data associated with some objects in the scene
@@ -10,14 +10,13 @@ import type { Object3D } from 'three'
  * objectB:
  *   onHover: [handler]
  *   onBlur:  [handler]
- *
  */
-export type ObjectsState<Key extends string, Value> = Map<Object3D, Record<Key, Value[]>>
+export type ObjectsState<Key extends string, Value> = Map<THREE.Object3D, Record<Key, Value[]>>
 export const ObjectsState = {
-  make: function <Key extends string, Value>() {
+  make<Key extends string, Value>() {
     return new Map() as ObjectsState<Key, Value>
   },
-  add: function <Key extends string, Value>(state: ObjectsState<Key, Value>, object: Object3D, key: Key, value: Value) {
+  add<Key extends string, Value>(state: ObjectsState<Key, Value>, object: THREE.Object3D, key: Key, value: Value) {
     if (!state.has(object)) {
       state.set(object, { key: [value] } as any)
     }
@@ -27,7 +26,7 @@ export const ObjectsState = {
     }
     entry[key].push(value)
   },
-  delete: function <Key extends string, Value>(state: ObjectsState<Key, Value>, object: Object3D, key: Key, value: Value) {
+  delete<Key extends string, Value>(state: ObjectsState<Key, Value>, object: THREE.Object3D, key: Key, value: Value) {
     const entry = state.get(object)
     if (!entry || !entry[key]) return
     entry[key] = entry[key].filter((it) => it !== value)
@@ -41,11 +40,11 @@ export const ObjectsState = {
       state.delete(object)
     }
   },
-  has: function <Key extends string, Value>(state: ObjectsState<Key, Value>, object: Object3D, key: Key) {
+  has<Key extends string, Value>(state: ObjectsState<Key, Value>, object: THREE.Object3D, key: Key) {
     const entry = state.get(object)
     return !!(entry && entry[key])
   },
-  get: function <Key extends string, Value>(state: ObjectsState<Key, Value>, object: Object3D, key: Key) {
+  get<Key extends string, Value>(state: ObjectsState<Key, Value>, object: THREE.Object3D, key: Key) {
     const entry = state.get(object)
     return entry && entry[key]
   }

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -1,63 +1,31 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import * as React from 'react'
-import { Canvas, useFrame, useThree } from '@react-three/fiber'
+import * as THREE from 'three'
+import { Canvas, useFrame, useThree, Props as ContainerProps } from '@react-three/fiber'
 import { ARButton } from './webxr/ARButton'
 import { VRButton } from './webxr/VRButton'
 import { XRController } from './XRController'
-import { Props as ContainerProps } from '@react-three/fiber/dist/declarations/src/web/Canvas'
 import { InteractionManager, InteractionsContext } from './Interactions'
-import type { WebGLRenderer } from 'three'
-import { Matrix4, Group } from 'three'
 
 export interface XRContextValue {
   controllers: XRController[]
   isPresenting: boolean
-  player: Group
+  player: THREE.Group
   isHandTracking: boolean
 }
 const XRContext = React.createContext<XRContextValue>({} as any)
 
-const useControllers = (group: Group): XRController[] => {
-  const { gl } = useThree()
-  const [controllers, setControllers] = React.useState<XRController[]>([])
-
-  React.useEffect(() => {
-    const ids = [0, 1]
-    ids.forEach((id) => {
-      XRController.make(
-        id,
-        gl,
-        (controller) => {
-          group.add(controller.controller)
-          group.add(controller.grip)
-          group.add(controller.hand)
-          setControllers((it) => [...it, controller])
-        },
-        (controller) => {
-          group.remove(controller.controller)
-          group.remove(controller.grip)
-          group.remove(controller.hand)
-          setControllers((existing) => existing.filter((it) => it !== controller))
-        }
-      )
-    })
-  }, [gl, group])
-
-  return controllers
-}
-
-export function useHitTest(hitTestCallback: (hitMatrix: Matrix4, hit: XRHitTestResult) => void) {
-  const { gl } = useThree()
-
+export type HitTestCallback = (hitMatrix: THREE.Matrix4, hit: XRHitTestResult) => void
+export function useHitTest(hitTestCallback: HitTestCallback) {
   const hitTestSource = React.useRef<XRHitTestSource | undefined>()
   const hitTestSourceRequested = React.useRef(false)
-  const [hitMatrix] = React.useState(() => new Matrix4())
+  const [hitMatrix] = React.useState(() => new THREE.Matrix4())
 
-  useFrame((_, __, frame) => {
-    if (!gl.xr.isPresenting) return
+  useFrame((state, _, frame) => {
+    if (!state.gl.xr.isPresenting) return
 
-    const session = gl.xr.getSession()
+    const session = state.gl.xr.getSession()
     if (!session) return
 
     if (!hitTestSourceRequested.current) {
@@ -77,8 +45,8 @@ export function useHitTest(hitTestCallback: (hitMatrix: Matrix4, hit: XRHitTestR
       hitTestSourceRequested.current = true
     }
 
-    if (hitTestSource.current && gl.xr.isPresenting && frame) {
-      const referenceSpace = gl.xr.getReferenceSpace()
+    if (hitTestSource.current && state.gl.xr.isPresenting && frame) {
+      const referenceSpace = state.gl.xr.getReferenceSpace()
 
       if (referenceSpace) {
         const hitTestResults = frame.getHitTestResults(hitTestSource.current as XRHitTestSource)
@@ -96,34 +64,38 @@ export function useHitTest(hitTestCallback: (hitMatrix: Matrix4, hit: XRHitTestR
   })
 }
 
-export function XR({ foveation = 0, children }: { foveation?: number; children: React.ReactNode }) {
-  const { gl, camera } = useThree()
+export interface XRProps {
+  foveation?: number
+  children: React.ReactNode
+}
+export function XR({ foveation = 0, children }: XRProps) {
+  const gl = useThree((state) => state.gl)
+  const camera = useThree((state) => state.camera)
   const [isPresenting, setIsPresenting] = React.useState(() => gl.xr.isPresenting)
   const [isHandTracking, setHandTracking] = React.useState(false)
-  const [player] = React.useState(() => new Group())
-  const controllers = useControllers(player)
+  const [player] = React.useState(() => new THREE.Group())
+  const [controllers, setControllers] = React.useState<XRController[]>([])
 
-  React.useEffect(() => {
-    const xr = gl.xr as any
+  React.useLayoutEffect(() => {
+    const controllers = [0, 1].map((id) => new XRController(id, gl))
+    setControllers(controllers)
 
-    const handleSessionChange = () => setIsPresenting(xr.isPresenting)
+    return () => controllers.forEach((controller) => controller.dispose())
+  }, [gl.xr])
 
-    xr.addEventListener('sessionstart', handleSessionChange)
-    xr.addEventListener('sessionend', handleSessionChange)
+  React.useLayoutEffect(() => {
+    const handleSessionChange = () => setIsPresenting(gl.xr.isPresenting)
+
+    gl.xr.addEventListener('sessionstart', handleSessionChange)
+    gl.xr.addEventListener('sessionend', handleSessionChange)
 
     return () => {
-      xr.removeEventListener('sessionstart', handleSessionChange)
-      xr.removeEventListener('sessionend', handleSessionChange)
+      gl.xr.removeEventListener('sessionstart', handleSessionChange)
+      gl.xr.removeEventListener('sessionend', handleSessionChange)
     }
-  }, [gl])
+  }, [gl.xr])
 
-  React.useEffect(() => {
-    const xr = gl.xr as any
-
-    if (xr.setFoveation) {
-      xr.setFoveation(foveation)
-    }
-  }, [gl, foveation])
+  React.useLayoutEffect(() => void gl.xr.setFoveation?.(foveation), [gl, foveation])
 
   React.useEffect(() => {
     const session = gl.xr.getSession()
@@ -150,6 +122,7 @@ export function XR({ foveation = 0, children }: { foveation?: number; children: 
     <XRContext.Provider value={value}>
       <primitive object={player} dispose={null}>
         <primitive object={camera} dispose={null} />
+        {controllers}
       </primitive>
       {children}
     </XRContext.Provider>
@@ -179,7 +152,7 @@ function XRCanvas({ foveation, children, ...rest }: Omit<XRCanvasProps, 'session
 
 export function useXRButton(
   mode: 'AR' | 'VR',
-  gl: WebGLRenderer,
+  gl: THREE.WebGLRenderer,
   sessionInit?: XRSessionInit,
   container?: React.MutableRefObject<HTMLElement>
 ) {

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -121,8 +121,10 @@ export function XR({ foveation = 0, children }: XRProps) {
   return (
     <XRContext.Provider value={value}>
       <primitive object={player} dispose={null}>
-        <primitive object={camera} dispose={null} />
-        {controllers}
+        <primitive object={camera} />
+        {controllers.map((controller, i) => (
+          <primitive key={`controller-${i}`} object={controller} />
+        ))}
       </primitive>
       {children}
     </XRContext.Provider>

--- a/src/XREvents.ts
+++ b/src/XREvents.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { XRController } from './XRController'
 import { useXR } from './XR'
 
@@ -9,24 +9,25 @@ export interface XREvent {
 
 export type XREventType = 'select' | 'selectstart' | 'selectend' | 'squeeze' | 'squeezestart' | 'squeezeend'
 
-export const useXREvent = (event: XREventType, handler: (e: XREvent) => any, { handedness }: { handedness?: XRHandedness } = {}) => {
+export function useXREvent(event: XREventType, handler: (e: XREvent) => any, handedness?: XRHandedness) {
   const handlerRef = React.useRef<(e: XREvent) => any>(handler)
-  React.useEffect(() => {
-    handlerRef.current = handler
-  }, [handler])
-  const { controllers: allControllers } = useXR()
+  React.useLayoutEffect(() => void (handlerRef.current = handler), [handler])
 
-  React.useEffect(() => {
-    const controllers = handedness ? allControllers.filter((it) => it.inputSource.handedness === handedness) : allControllers
+  const { controllers } = useXR()
+  const targets = React.useMemo(
+    () => (handedness ? controllers.filter((controller) => controller.inputSource.handedness === handedness) : controllers),
+    [handedness, controllers]
+  )
 
-    const cleanups: any[] = []
+  React.useLayoutEffect(() => {
+    const cleanups: (() => void)[] = []
 
-    controllers.forEach((it) => {
-      const listener = (e: any) => handlerRef.current({ originalEvent: e, controller: it })
-      it.controller.addEventListener(event, listener)
-      cleanups.push(() => it.controller.removeEventListener(event, listener))
+    targets.forEach((target) => {
+      const listener = (e: any) => handlerRef.current({ originalEvent: e, controller: target })
+      target.controller.addEventListener(event, listener)
+      cleanups.push(() => target.controller.removeEventListener(event, listener))
     })
 
-    return () => cleanups.forEach((fn) => fn())
-  }, [event, allControllers, handedness])
+    return () => cleanups.forEach((cleanup) => cleanup())
+  }, [targets, event])
 }


### PR DESCRIPTION
Abstracts XRController into a more re-usable class that will bubble up events and dispose properly. Also uses `useLayoutEffect` internally where appropriate to minimize race conditions with R3F, and drops `react-merge-refs` in favor of `useImperativeHandle`.