### PR TITLE
fix: don't create matrices on useframe, re-use hitmatrix

### DIFF
--- a/src/Interactions.tsx
+++ b/src/Interactions.tsx
@@ -221,7 +221,7 @@ export function RayGrab({ children }: { children: ReactNode }) {
     group.applyMatrix4(controller.matrixWorld)
     group.updateWorldMatrix(false, true)
 
-    previousTransform.current = controller.matrixWorld.clone().invert()
+    previousTransform.current.copy(controller.matrixWorld).invert()
   })
 
   return (

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -55,12 +55,13 @@ const useControllers = (group: Group): XRController[] => {
   return controllers
 }
 
+const hitMatrix = new Matrix4()
+
 export function useHitTest(hitTestCallback: (hitMatrix: Matrix4, hit: XRHitTestResult) => void) {
   const { gl } = useThree()
 
   const hitTestSource = React.useRef<XRHitTestSource | undefined>()
   const hitTestSourceRequested = React.useRef(false)
-  const [hitMatrix] = React.useState(() => new Matrix4())
 
   useFrame(() => {
     if (!gl.xr.isPresenting) return


### PR DESCRIPTION
Prefers to copy & re-use matrices in performance-sensitive code paths. Should hopefully remedy #30 if still current (needs reproduction).