### PR TITLE
refactor: make XREvent and XREventHandler generic

### DIFF
--- a/src/Interactions.tsx
+++ b/src/Interactions.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import { useThree, useFrame } from '@react-three/fiber'
 import { useXR } from './XR'
 import { XRController } from './XRController'
-import { useXREvent, XREvent } from './XREvents'
+import { useXREvent, XREvent, XRControllerEvent } from './XREvents'
 
 export interface XRInteractionEvent {
   intersection?: THREE.Intersection
@@ -90,7 +90,7 @@ export function InteractionManager({ children }: { children: React.ReactNode }) 
   })
 
   const triggerEvent = React.useCallback(
-    (interaction: XRInteractionType) => (e: XREvent) => {
+    (interaction: XRInteractionType) => (e: XREvent<XRControllerEvent>) => {
       const hovering = hoverState[e.target.inputSource.handedness]
       for (const hovered of hovering.keys()) {
         getInteraction(hovered, interaction)?.forEach((handler) => handler({ target: e.target, intersection: hovering.get(hovered) }))

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -176,9 +176,7 @@ function XR({
       }
     })
 
-    return () => {
-      handlers.forEach((cleanup) => cleanup())
-    }
+    return () => handlers.forEach((cleanup) => cleanup())
   }, [gl, set, player])
 
   React.useEffect(() => void gl.xr.setSession(session!), [gl.xr, session])

--- a/src/XRController.tsx
+++ b/src/XRController.tsx
@@ -1,4 +1,5 @@
 import * as THREE from 'three'
+import { XRControllerEvent } from './XREvents'
 
 export class XRController extends THREE.Group {
   readonly index: number
@@ -6,8 +7,6 @@ export class XRController extends THREE.Group {
   readonly grip: THREE.XRGripSpace
   readonly hand: THREE.XRHandSpace
   inputSource!: XRInputSource
-  onConnected: (event: any) => void
-  onDisconnected: (event: any) => void
 
   constructor(index: number, gl: THREE.WebGLRenderer) {
     super()
@@ -24,23 +23,26 @@ export class XRController extends THREE.Group {
     this.visible = false
     this.add(this.controller, this.grip, this.hand)
 
-    this.onConnected = (event: any) => {
-      if (event.fake) return
-
-      this.visible = true
-      this.inputSource = event.data
-      this.dispatchEvent(event)
-    }
-
-    this.onDisconnected = (event: any) => {
-      if (event.fake) return
-
-      this.visible = false
-      this.dispatchEvent(event)
-    }
+    this.onConnected = this.onConnected.bind(this)
+    this.onDisconnected = this.onDisconnected.bind(this)
 
     this.controller.addEventListener('connected', this.onConnected)
     this.controller.addEventListener('disconnected', this.onDisconnected)
+  }
+
+  onConnected(event: XRControllerEvent) {
+    if (event.fake) return
+
+    this.visible = true
+    this.inputSource = event.data!
+    this.dispatchEvent(event)
+  }
+
+  onDisconnected(event: XRControllerEvent) {
+    if (event.fake) return
+
+    this.visible = false
+    this.dispatchEvent(event)
   }
 
   dispose() {

--- a/src/XREvents.ts
+++ b/src/XREvents.ts
@@ -2,15 +2,22 @@ import * as React from 'react'
 import { XRController } from './XRController'
 import { useXR } from './XR'
 
-export type XREventType = 'select' | 'selectstart' | 'selectend' | 'squeeze' | 'squeezestart' | 'squeezeend'
-export interface XREvent {
-  nativeEvent: any
+export type XREventRepresentation = { type: string; target: any }
+export interface XREvent<T extends XREventRepresentation> {
+  nativeEvent: T
+  target: T['target']
+}
+
+export type XRControllerEventType = Exclude<THREE.XRControllerEventType, XRSessionEventType>
+export interface XRControllerEvent {
+  type: XRControllerEventType
   target: XRController
 }
-export type XREventHandler = (event: XREvent) => void
 
-export function useXREvent(event: XREventType, handler: XREventHandler, handedness?: XRHandedness) {
-  const handlerRef = React.useRef<XREventHandler>(handler)
+export type XREventHandler<T extends XREventRepresentation> = (event: XREvent<T>) => void
+
+export function useXREvent(event: XRControllerEventType, handler: XREventHandler<XRControllerEvent>, handedness?: XRHandedness) {
+  const handlerRef = React.useRef<XREventHandler<XRControllerEvent>>(handler)
   React.useEffect(() => void (handlerRef.current = handler), [handler])
   const allControllers = useXR((state) => state.controllers)
   const controllers = React.useMemo(


### PR DESCRIPTION
Fixes https://github.com/pmndrs/react-xr/pull/142#discussion_r900048298 by making the `XREvent` and `XREventHandler` interfaces generic, and extending to `XRControllerEvent`, `XRManagerEvent`, and `XRSessionEvent` (built-in).