### PR TITLE
refactor: break up DefaultXRControllers, manage DefaultXRControllers and Hands in R3F

### DIFF
--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -14,11 +14,12 @@ export const ControllerModel = React.forwardRef<XRControllerModel, ControllerMod
   { target, ...props },
   forwardedRef
 ) {
-  const model = React.useMemo(() => {
-    const controllerModel = modelFactory.createControllerModel(target.controller)
-    target.controller.dispatchEvent({ type: 'connected', data: target.inputSource, fake: true })
-    return controllerModel
-  }, [target.controller, target.inputSource])
+  const model = React.useMemo(() => modelFactory.createControllerModel(target.controller), [target.controller])
+
+  React.useEffect(
+    () => void target.controller.dispatchEvent({ type: 'connected', data: target.inputSource, fake: true }),
+    [target.controller, target.inputSource]
+  )
 
   return <>{createPortal(<primitive {...props} ref={forwardedRef} object={model} />, target.grip)}</>
 })

--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -16,12 +16,13 @@ export const ControllerModel = React.forwardRef<XRControllerModel, ControllerMod
 ) {
   const model = React.useMemo(() => modelFactory.createControllerModel(target.controller), [target.controller])
 
+  // Dispatch fake connected event to start loading model on mount
   React.useEffect(
     () => void target.controller.dispatchEvent({ type: 'connected', data: target.inputSource, fake: true }),
     [target.controller, target.inputSource]
   )
 
-  return <>{createPortal(<primitive {...props} ref={forwardedRef} object={model} />, target.grip)}</>
+  return <primitive {...props} ref={forwardedRef} object={model} />
 })
 
 export interface RayProps extends Partial<JSX.IntrinsicElements['mesh']> {
@@ -50,15 +51,10 @@ export const Ray = React.forwardRef<THREE.Mesh, RayProps>(function Ray({ target,
   })
 
   return (
-    <>
-      {createPortal(
-        <mesh ref={ray} {...props}>
-          <boxGeometry args={[0.002, 1, 0.002]} />
-          <meshBasicMaterial opacity={0.8} transparent />
-        </mesh>,
-        target.controller
-      )}
-    </>
+    <mesh ref={ray} {...props}>
+      <boxGeometry args={[0.002, 1, 0.002]} />
+      <meshBasicMaterial opacity={0.8} transparent />
+    </mesh>
   )
 })
 
@@ -85,10 +81,10 @@ export const DefaultXRControllers = React.forwardRef<THREE.Group, DefaultXRContr
 
   return (
     <group {...props} ref={forwardedRef}>
-      {controllers.map((controller, i) => (
+      {controllers.map((target, i) => (
         <group key={`controller-${i}`}>
-          <ControllerModel target={controller} />
-          <Ray target={controller} {...rayMaterialProps} />
+          {createPortal(<ControllerModel target={target} />, target.grip)}
+          {createPortal(<Ray target={target} {...rayMaterialProps} />, target.controller)}
         </group>
       ))}
     </group>

--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -31,9 +31,8 @@ export const Ray = React.forwardRef<THREE.Mesh, RayProps>(function Ray({ target,
   })
 
   return (
-    <mesh ref={ray} rotation-x={Math.PI / 2} {...props}>
+    <mesh ref={ray} rotation-x={Math.PI / 2} material-opacity={0.8} material-transparent={true} {...props}>
       <boxGeometry args={[0.002, 1, 0.002]} />
-      <meshBasicMaterial opacity={0.8} transparent />
     </mesh>
   )
 })

--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -51,7 +51,7 @@ export const Ray = React.forwardRef<THREE.Mesh, RayProps>(function Ray({ target,
   })
 
   return (
-    <mesh ref={ray} {...props}>
+    <mesh ref={ray} rotation-x={Math.PI / 2} {...props}>
       <boxGeometry args={[0.002, 1, 0.002]} />
       <meshBasicMaterial opacity={0.8} transparent />
     </mesh>
@@ -77,9 +77,9 @@ export function DefaultXRControllers({ rayMaterial = {} }: DefaultXRControllersP
   )
 
   return controllers.map((target, i) => (
-    <group key={`controller-${i}`}>
+    <React.Fragment key={`controller-${i}`}>
       {createPortal(<ControllerModel target={target} />, target.grip)}
       {createPortal(<Ray target={target} {...rayMaterialProps} />, target.controller)}
-    </group>
+    </React.Fragment>
   ))
 }

--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -58,14 +58,11 @@ export const Ray = React.forwardRef<THREE.Mesh, RayProps>(function Ray({ target,
   )
 })
 
-export interface DefaultXRControllersProps extends Partial<JSX.IntrinsicElements['group']> {
+export interface DefaultXRControllersProps {
   /** Optional material props to pass to controllers' ray indicators */
   rayMaterial?: JSX.IntrinsicElements['meshBasicMaterial']
 }
-export const DefaultXRControllers = React.forwardRef<THREE.Group, DefaultXRControllersProps>(function DefaultXRControllers(
-  { rayMaterial = {}, ...props },
-  forwardedRef
-) {
+export function DefaultXRControllers({ rayMaterial = {} }: DefaultXRControllersProps) {
   const controllers = useXR((state) => state.controllers)
   const rayMaterialProps = React.useMemo(
     () =>
@@ -79,14 +76,10 @@ export const DefaultXRControllers = React.forwardRef<THREE.Group, DefaultXRContr
     [rayMaterial]
   )
 
-  return (
-    <group {...props} ref={forwardedRef}>
-      {controllers.map((target, i) => (
-        <group key={`controller-${i}`}>
-          {createPortal(<ControllerModel target={target} />, target.grip)}
-          {createPortal(<Ray target={target} {...rayMaterialProps} />, target.controller)}
-        </group>
-      ))}
+  return controllers.map((target, i) => (
+    <group key={`controller-${i}`}>
+      {createPortal(<ControllerModel target={target} />, target.grip)}
+      {createPortal(<Ray target={target} {...rayMaterialProps} />, target.controller)}
     </group>
-  )
-})
+  ))
+}


### PR DESCRIPTION
Refactors `DefaultXRControllers` and `Hands` to manage its rays and models in R3F to prevent memory leaks. Also breaks up rays into a separate exported `Rays` component.