### PR TITLE
feat(Ray): add option to hide on blur (show by default)

### DIFF
--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -20,10 +20,11 @@ export const Ray = React.forwardRef<THREE.Line, RayProps>(function Ray({ target,
   )
   React.useImperativeHandle(forwardedRef, () => ray.current)
 
+  // Hide ray when swapping to hand controllers
+  React.useEffect(() => void (ray.current.visible = !target.inputSource.hand), [target.inputSource.hand])
+
   // Show ray line when hovering objects
   useFrame(() => {
-    if (!ray.current) return
-
     let rayLength = 1
 
     const intersection: THREE.Intersection = hoverState[target.inputSource.handedness].values().next().value

--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -66,7 +66,7 @@ export function DefaultXRControllers({ rayMaterial = {}, hideRaysOnBlur = false 
         }),
         {}
       ),
-    [rayMaterial]
+    [JSON.stringify(rayMaterial)]
   )
 
   React.useEffect(() => {

--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -27,7 +27,6 @@ export const Ray = React.forwardRef<THREE.Line, RayProps>(function Ray({ target,
     let rayLength = 1
 
     const intersection: THREE.Intersection = hoverState[target.inputSource.handedness].values().next().value
-    console.log(intersection && target.inputSource.handedness !== 'none')
     if (intersection && target.inputSource.handedness !== 'none') {
       rayLength = intersection.distance
       if (hideOnBlur) ray.current.visible = false

--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -12,8 +12,9 @@ export interface RayProps extends Partial<JSX.IntrinsicElements['object3D']> {
   hideOnBlur?: boolean
 }
 export const Ray = React.forwardRef<THREE.Line, RayProps>(function Ray({ target, hideOnBlur = false, ...props }, forwardedRef) {
-  const ray = React.useRef<THREE.Line>(null!)
+  const isHandTracking = useXR((state) => state.isHandTracking)
   const hoverState = useXR((state) => state.hoverState)
+  const ray = React.useRef<THREE.Line>(null!)
   const rayGeometry = React.useMemo(
     () => new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0, 0, 0), new THREE.Vector3(0, 0, -1)]),
     []
@@ -21,7 +22,7 @@ export const Ray = React.forwardRef<THREE.Line, RayProps>(function Ray({ target,
   React.useImperativeHandle(forwardedRef, () => ray.current)
 
   // Hide ray when swapping to hand controllers
-  React.useEffect(() => void (ray.current.visible = !target.inputSource.hand), [target.inputSource.hand])
+  React.useEffect(() => void (ray.current.visible = !isHandTracking), [isHandTracking])
 
   // Show ray line when hovering objects
   useFrame(() => {


### PR DESCRIPTION
Implements #87 by adding a `hideOnBlur` prop to `Ray` which would be passed from `hideRaysOnBlur` of `DefaultXRControllers`. This is disabled by default with rays persisting by default.

This would be more inline with menu ray representations and examples like https://threejs.org/examples/#webxr_vr_dragging.