### PR TITLE
feat: add onSelectMissed and onSqueezeMissed interactions

### DIFF
--- a/src/Interactions.tsx
+++ b/src/Interactions.tsx
@@ -127,7 +127,7 @@ export function InteractionManager({ children }: { children: React.ReactNode }) 
         }
       })
     },
-    [hoverState, getInteraction]
+    [hoverState, interactions]
   )
 
   useXREvent('select', triggerEvent('onSelect'))

--- a/src/Interactions.tsx
+++ b/src/Interactions.tsx
@@ -21,6 +21,7 @@ export type XRInteractionType =
   | 'onSqueeze'
   | 'onSqueezeEnd'
   | 'onSqueezeStart'
+  | 'onSqueezeMissed'
 
 export type XRInteractionHandler = (event: XRInteractionEvent) => any
 
@@ -116,6 +117,10 @@ export function InteractionManager({ children }: { children: React.ReactNode }) 
         } else {
           if (interaction === 'onSelect' && handlers['onSelectMissed']) {
             for (const handler of handlers['onSelectMissed']) {
+              handler({ target: e.target, intersections })
+            }
+          } else if (interaction === 'onSqueeze' && handlers['onSqueezeMissed']) {
+            for (const handler of handlers['onSqueezeMissed']) {
               handler({ target: e.target, intersections })
             }
           }

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -61,7 +61,8 @@ const XRStore = create<XRState>((set, get) => ({
         onSelectMissed: [],
         onSqueeze: [],
         onSqueezeEnd: [],
-        onSqueezeStart: []
+        onSqueezeStart: [],
+        onSqueezeMissed: []
       })
     }
 

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -55,9 +55,10 @@ const XRStore = create<XRState>((set, get) => ({
       interactions.set(object, {
         onHover: [],
         onBlur: [],
-        onSelectStart: [],
-        onSelectEnd: [],
         onSelect: [],
+        onSelectEnd: [],
+        onSelectStart: [],
+        onSelectMissed: [],
         onSqueeze: [],
         onSqueezeEnd: [],
         onSqueezeStart: []


### PR DESCRIPTION
Continues #91. Adds `onSelectMissed` and `onSqueezeMissed` interaction handlers.