### PR TITLE
fix: wrap portals in fragment

### DIFF
--- a/src/DefaultXRControllers.tsx
+++ b/src/DefaultXRControllers.tsx
@@ -88,10 +88,17 @@ export function DefaultXRControllers({ rayMaterial = {}, hideRaysOnBlur = false 
     }
   }, [controllers])
 
-  return controllers.map((target, i) => (
-    <React.Fragment key={i}>
-      {createPortal(<defaultXRController args={[target]} />, target.grip)}
-      {createPortal(<Ray visible={!isHandTracking} hideOnBlur={hideRaysOnBlur} target={target} {...rayMaterialProps} />, target.controller)}
-    </React.Fragment>
-  ))
+  return (
+    <>
+      {controllers.map((target, i) => (
+        <React.Fragment key={i}>
+          {createPortal(<defaultXRController args={[target]} />, target.grip)}
+          {createPortal(
+            <Ray visible={!isHandTracking} hideOnBlur={hideRaysOnBlur} target={target} {...rayMaterialProps} />,
+            target.controller
+          )}
+        </React.Fragment>
+      ))}
+    </>
+  )
 }

--- a/src/Hands.tsx
+++ b/src/Hands.tsx
@@ -26,5 +26,5 @@ export function Hands({ modelLeft, modelRight }: HandsProps) {
     }
   }, [controllers, modelLeft, modelRight])
 
-  return controllers.map(({ hand }) => createPortal(<oculusHandModel args={[hand, modelLeft, modelRight]} />, hand))
+  return <>{controllers.map(({ hand }) => createPortal(<oculusHandModel args={[hand, modelLeft, modelRight]} />, hand))}</>
 }


### PR DESCRIPTION
Fixes #161 by wrapping controllers' portal containers in a react fragment.