### PR TITLE
fix: disable JSX transform

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   server: {
     https: true
   },
-  plugins: [react()],
+  plugins: [react({ jsxRuntime: 'classic' })],
   publicDir: process.env.NODE_ENV === 'production' ? false : 'public',
   root: 'examples',
   resolve: {


### PR DESCRIPTION
Mirrors #168 and disables automatic JSX transform which wrongly inexplicitly imports from `react/jsx-transform` in ESM bundles. This was enabled by default since #138.