### PR TITLE
Fixed outdated callbacks

### DIFF
--- a/src/Interactions.tsx
+++ b/src/Interactions.tsx
@@ -116,16 +116,16 @@ export function InteractionManager({ children }: { children: React.ReactNode }) 
           if (!handlers[interaction]) return
 
           for (const handler of handlers[interaction]) {
-            handler({ target: e.target, intersection: hovering.get(object), intersections })
+            handler.current?.({ target: e.target, intersection: hovering.get(object), intersections })
           }
         } else {
           if (interaction === 'onSelect' && handlers['onSelectMissed']) {
             for (const handler of handlers['onSelectMissed']) {
-              handler({ target: e.target, intersections })
+              handler.current?.({ target: e.target, intersections })
             }
           } else if (interaction === 'onSqueeze' && handlers['onSqueezeMissed']) {
             for (const handler of handlers['onSqueezeMissed']) {
-              handler({ target: e.target, intersections })
+              handler.current?.({ target: e.target, intersections })
             }
           }
         }
@@ -147,17 +147,16 @@ export function InteractionManager({ children }: { children: React.ReactNode }) 
 export function useInteraction(ref: React.RefObject<THREE.Object3D>, type: XRInteractionType, handler?: XRInteractionHandler) {
   const addInteraction = useXR((state) => state.addInteraction)
   const removeInteraction = useXR((state) => state.removeInteraction)
-  const handlerRef = React.useRef(handler)
-  React.useEffect(() => void (handlerRef.current = handler), [handler])
+  const handlerRef = React.useRef<XRInteractionHandler | null>(handler ?? null)
+  React.useEffect(() => void (handlerRef.current = handler ?? null), [handler])
 
   React.useEffect(() => {
     const target = ref.current
-    const handler = handlerRef.current
-    if (!target || !handler) return
+    if (!target || !handlerRef.current) return
 
-    addInteraction(target, type, handler)
+    addInteraction(target, type, handlerRef)
 
-    return () => removeInteraction(target, type, handler)
+    return () => removeInteraction(target, type, handlerRef)
   }, [ref, type, addInteraction, removeInteraction])
 }
 

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -19,11 +19,11 @@ export interface XRState {
   referenceSpace: XRReferenceSpaceType
 
   hoverState: Record<XRHandedness, Map<THREE.Object3D, THREE.Intersection>>
-  interactions: Map<THREE.Object3D, Record<XRInteractionType, XRInteractionHandler[]>>
+  interactions: Map<THREE.Object3D, Record<XRInteractionType, React.RefObject<XRInteractionHandler>[]>>
   hasInteraction: (object: THREE.Object3D, eventType: XRInteractionType) => boolean
   getInteraction: (object: THREE.Object3D, eventType: XRInteractionType) => XRInteractionHandler[] | undefined
-  addInteraction: (object: THREE.Object3D, eventType: XRInteractionType, handler: XRInteractionHandler) => void
-  removeInteraction: (object: THREE.Object3D, eventType: XRInteractionType, handler: XRInteractionHandler) => void
+  addInteraction: (object: THREE.Object3D, eventType: XRInteractionType, handlerRef: React.RefObject<XRInteractionHandler>) => void
+  removeInteraction: (object: THREE.Object3D, eventType: XRInteractionType, handlerRef: React.RefObject<XRInteractionHandler>) => void
 }
 const XRContext = React.createContext<UseBoundStore<XRState>>(null!)
 
@@ -178,12 +178,21 @@ export function XR(props: XRProps) {
         },
         interactions: new Map(),
         hasInteraction(object: THREE.Object3D, eventType: XRInteractionType) {
-          return !!get().interactions.get(object)?.[eventType].length
+          return !!get()
+            .interactions.get(object)
+            ?.[eventType].some((handlerRef) => handlerRef.current)
         },
         getInteraction(object: THREE.Object3D, eventType: XRInteractionType) {
-          return get().interactions.get(object)?.[eventType]
+          return get()
+            .interactions.get(object)
+            ?.[eventType].reduce((result, handlerRef) => {
+              if (handlerRef.current) {
+                result.push(handlerRef.current)
+              }
+              return result
+            }, [] as XRInteractionHandler[])
         },
-        addInteraction(object: THREE.Object3D, eventType: XRInteractionType, handler: XRInteractionHandler) {
+        addInteraction(object: THREE.Object3D, eventType: XRInteractionType, handlerRef: React.RefObject<XRInteractionHandler>) {
           const interactions = get().interactions
           if (!interactions.has(object)) {
             interactions.set(object, {
@@ -202,12 +211,12 @@ export function XR(props: XRProps) {
           }
 
           const target = interactions.get(object)!
-          target[eventType].push(handler)
+          target[eventType].push(handlerRef)
         },
-        removeInteraction(object: THREE.Object3D, eventType: XRInteractionType, handler: XRInteractionHandler) {
+        removeInteraction(object: THREE.Object3D, eventType: XRInteractionType, handlerRef: React.RefObject<XRInteractionHandler>) {
           const target = get().interactions.get(object)
           if (target) {
-            const interactionIndex = target[eventType].indexOf(handler)
+            const interactionIndex = target[eventType].indexOf(handlerRef)
             if (interactionIndex !== -1) target[eventType].splice(interactionIndex, 1)
           }
         }


### PR DESCRIPTION
By storing callback refs instead of callbacks themselves. Honestly I struggle to understand how it even worked before. Alternative approach would be as it was before v4, https://github.com/pmndrs/react-xr/blob/v3/src/Interactions.tsx#L157-L168. Current approach is better in a way that's handling null/undefined callbacks more correctly and efficiently, for instance an object with null callbacks with have data in interactions map but will be considered empty by `hasInteraction` (although it will require additional iteration)

Fixes #182