### PR TITLE
docs: prefer Matrix4#decompose in hit test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,7 @@ Use this hook to perform a hit test for an AR environment. Also see [`XRHitTestR
 ```tsx
 useHitTest((hitMatrix: Matrix4, hit: XRHitTestResult) => {
   // use hitMatrix to position any object on the real life surface
-  mesh.matrixAutoUpdate = false
-  mesh.matrix = hitMatrix
+  hitMatrix.decompose(mesh.position, mesh.quaternion, mesh.scale)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ Use this hook to perform a hit test for an AR environment. Also see [`XRHitTestR
 ```tsx
 useHitTest((hitMatrix: Matrix4, hit: XRHitTestResult) => {
   // use hitMatrix to position any object on the real life surface
-  mesh.applyMatrix4(hitMatrix)
+  mesh.matrixAutoUpdate = false
+  mesh.matrix = hitMatrix
 })
 ```
 

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -32,7 +32,10 @@ function PlayerExample() {
 
 function HitTestExample() {
   const boxRef = React.useRef<THREE.Mesh>(null!)
-  useHitTest((hitMatrix) => boxRef.current.applyMatrix4(hitMatrix))
+  useHitTest((hitMatrix) => {
+    boxRef.current.matrixAutoUpdate = false
+    boxRef.current.matrix = hitMatrix
+  })
 
   return <Box ref={boxRef} args={[0.1, 0.1, 0.1]} />
 }

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -33,8 +33,7 @@ function PlayerExample() {
 function HitTestExample() {
   const boxRef = React.useRef<THREE.Mesh>(null!)
   useHitTest((hitMatrix) => {
-    boxRef.current.matrixAutoUpdate = false
-    boxRef.current.matrix = hitMatrix
+    hitMatrix.decompose(boxRef.current.position, boxRef.current.quaternion, boxRef.current.scale)
   })
 
   return <Box ref={boxRef} args={[0.1, 0.1, 0.1]} />


### PR DESCRIPTION
Resolves #203.

The useHitTest example wasn't working correctly. This updated code disables the target's matrixAutoUpdate and applies the hitMatrix directly to its matrix property (as per this example: https://github.com/immersive-web/webxr-samples/blob/main/hit-test.html)