### PR TITLE
chore: set up SSL for development environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/three": "^0.141.0",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
+    "@vitejs/plugin-basic-ssl": "^0.1.2",
     "@vitejs/plugin-react": "^2.0.0",
     "eslint": "^8.8.0",
     "eslint-config-prettier": "^8.3.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,13 @@
 import path from 'path'
 import react from '@vitejs/plugin-react'
+import ssl from '@vitejs/plugin-basic-ssl'
 import { defineConfig } from 'vite'
 
 const config = {
   serve: {
     root: 'examples',
-    plugins: [react()],
+    plugins: [react(), ssl()],
+    server: { host: true, https: true },
     resolve: {
       alias: {
         '@react-three/xr': path.resolve(process.cwd(), 'src')

--- a/yarn.lock
+++ b/yarn.lock
@@ -603,6 +603,11 @@
   dependencies:
     "@use-gesture/core" "10.2.15"
 
+"@vitejs/plugin-basic-ssl@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-0.1.2.tgz#7177f9adc5384f1377b9b91b17ce7cdb8f422abd"
+  integrity sha512-EdwCHnbkakR6YPupySZm1WoCDRPaw9c5jObAo2pCRv8Ja2TESFC6Sc8RUOcKuihfjARDfszbBf+YEQwHY9s9wg==
+
 "@vitejs/plugin-react@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-2.0.0.tgz#12decd097773a00620e44b780b1d2c00df101449"


### PR DESCRIPTION
I'm not sure how much of the WebXR API has this requirement, but at least when accessing the new Immersive AR ("passthrough") mode on a Quest headset, I need HTTPS to develop. Ran into this quickly while looking into some other things on the repository here and thought I'd push the change up if you're interested.

> ⚠️ **NOTE:** The browser will complain about an unrecognized HTTPS certificate when accessing a local development server for the first time. Accept the warnings, and you'll be able to access the examples.

*This contribution is funded by [R&D, The New York Times](https://rd.nytimes.com/).*