### PR TITLE
feat(XRButton): add `onError` prop for XR init

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ function App() {
   enterOnly={false}
   /** Whether this button should only exit an `XRSession`. Default is `false` */
   exitOnly={false}
+  /** This callback gets fired if XR initialization fails. */
+  onError={(error) => ...}
 >
   {/* Can accept regular DOM children and has an optional callback with the XR button status (unsupported, exited, entered) */}
   {(status) => `WebXR ${status}`}

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -42,7 +42,10 @@ function HitTestExample() {
 function App() {
   return (
     <>
-      <VRButton />
+      <VRButton onInitialisationError={e => {
+        console.error(e);
+        alert(e);
+      }} />
       <Canvas>
         <XR>
           <ambientLight intensity={0.5} />

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -42,10 +42,7 @@ function HitTestExample() {
 function App() {
   return (
     <>
-      <VRButton onError={e => {
-        console.error(e);
-        alert(e);
-      }} />
+      <VRButton onError={(e) => console.error(e)} />
       <Canvas>
         <XR>
           <ambientLight intensity={0.5} />

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -42,7 +42,7 @@ function HitTestExample() {
 function App() {
   return (
     <>
-      <VRButton onInitialisationError={e => {
+      <VRButton onError={e => {
         console.error(e);
         alert(e);
       }} />

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -282,6 +282,7 @@ export const XRButton = React.forwardRef<HTMLButtonElement, XRButtonProps>(funct
   const [status, setStatus] = React.useState<XRButtonStatus>('exited')
   const label = status === 'unsupported' ? `${mode} unsupported` : `${status === 'entered' ? 'Exit' : 'Enter'} ${mode}`
   const sessionMode = (mode === 'inline' ? mode : `immersive-${mode.toLowerCase()}`) as XRSessionMode
+  const onErrorRef = useCallbackRef(onError)
 
   useIsomorphicLayoutEffect(() => {
     if (!navigator?.xr) return void setStatus('unsupported')
@@ -322,16 +323,13 @@ export const XRButton = React.forwardRef<HTMLButtonElement, XRButtonProps>(funct
         }
 
         xrState.set(() => ({ session }))
-      } catch (e: any) {
-        if (onError && e instanceof Error) {
-          onError(e)
-          return
-        }
-
-        throw e
+      } catch (e) {
+        const onError = onErrorRef.current
+        if (onError && e instanceof Error) onError(e)
+        else throw e
       }
     },
-    [onClick, enterOnly, exitOnly, sessionMode, sessionInit]
+    [onClick, enterOnly, exitOnly, sessionMode, sessionInit, onErrorRef]
   )
 
   return (

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -238,7 +238,7 @@ export function XR(props: XRProps) {
 }
 
 export type XRButtonStatus = 'unsupported' | 'exited' | 'entered'
-export interface XRButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+export interface XRButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'onError'> {
   /** The type of `XRSession` to create */
   mode: 'AR' | 'VR' | 'inline'
   /**
@@ -251,7 +251,7 @@ export interface XRButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButto
   /** Whether this button should only exit an `XRSession`. Default is `false` */
   exitOnly?: boolean
   /** This callback gets fired if XR initialisation fails. */
-  onInitialisationError?: (error: Error) => void
+  onError?: (error: Error) => void
   /** React children, can also accept a callback returning an `XRButtonStatus` */
   children?: React.ReactNode | ((status: XRButtonStatus) => React.ReactNode)
 }
@@ -276,7 +276,7 @@ const getSessionOptions = (
 }
 
 export const XRButton = React.forwardRef<HTMLButtonElement, XRButtonProps>(function XRButton(
-  { mode, sessionInit, enterOnly = false, exitOnly = false, onClick, onInitialisationError, children, ...props },
+  { mode, sessionInit, enterOnly = false, exitOnly = false, onClick, onError, children, ...props },
   ref
 ) {
   const [status, setStatus] = React.useState<XRButtonStatus>('exited')
@@ -323,8 +323,8 @@ export const XRButton = React.forwardRef<HTMLButtonElement, XRButtonProps>(funct
 
         xrState.set(() => ({ session }))
       } catch(e: any) {
-        if(onInitialisationError && e instanceof Error) {
-          onInitialisationError(e);
+        if(onError && e instanceof Error) {
+          onError(e);
           return;
         }
 

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -250,7 +250,7 @@ export interface XRButtonProps extends Omit<React.ButtonHTMLAttributes<HTMLButto
   enterOnly?: boolean
   /** Whether this button should only exit an `XRSession`. Default is `false` */
   exitOnly?: boolean
-  /** This callback gets fired if XR initialisation fails. */
+  /** This callback gets fired if XR initialization fails. */
   onError?: (error: Error) => void
   /** React children, can also accept a callback returning an `XRButtonStatus` */
   children?: React.ReactNode | ((status: XRButtonStatus) => React.ReactNode)
@@ -322,13 +322,13 @@ export const XRButton = React.forwardRef<HTMLButtonElement, XRButtonProps>(funct
         }
 
         xrState.set(() => ({ session }))
-      } catch(e: any) {
-        if(onError && e instanceof Error) {
-          onError(e);
-          return;
+      } catch (e: any) {
+        if (onError && e instanceof Error) {
+          onError(e)
+          return
         }
 
-        throw e;
+        throw e
       }
     },
     [onClick, enterOnly, exitOnly, sessionMode, sessionInit]


### PR DESCRIPTION
Allows the user to handle failures to initialise - for example in firefox, XR support may be on, but there are no connected devices. Or, when the user rejects the prompt.