### PR TITLE
fix: hand mesh not visible after tracking lost/restored

### DIFF
--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -153,8 +153,8 @@ function XRManager({
     <InteractionManager>
       <primitive object={player}>
         <primitive object={camera} />
-        {controllers.map((controller, i) => (
-          <primitive key={i} object={controller} />
+        {controllers.map((controller) => (
+          <primitive key={controller.index} object={controller} />
         ))}
       </primitive>
       {children}


### PR DESCRIPTION
This should fix issue #213, but it might be a workaround for a more fundamental bug.

I recreated the problem without all the XR hand input event hassle. The issue currently arises when 2 array items are reversed in their order __and__ the react key prop of the array is used. An example of that is [here](https://github.com/bodo22/webxr-puzzle/blob/debug-primitive-swap/src/components/canvas/BuggyMinimalXR.jsx#L85).

The root of the Problem seems to be with [switchInstance](https://github.com/pmndrs/react-three-fiber/blob/master/packages/fiber/src/core/renderer.ts#L247) in react-three-fiber. In the specific buggy scenario, switchInstance removes the second element from the parent and adds as it the first. (in the first switch), then it removes that element from the parent in the second switch (which it shouldn't). So it kind of has an old state? Maybe switchInstance should only remove elements when the position in the parent is the same?

This fix (not relying on array index anymore) causes switchInstance to not be called anymore. 

For more info on why this "swapping" happens with the Quest 2:
When the Quest 2 fires an [inputsourceschange](https://developer.mozilla.org/en-US/docs/Web/API/XRSession/inputsourceschange_event) event when you move a hand out of the hand tracked area, there is the removed tracked hand in the "removed" array, but also an inputsource in the "added" array. I am not sure why, maybe this is a fallback? Nonetheless, this causes 2 immediate sync events in three.js: [disconnect, connect]. In the listeners in XR.js, zustand (rightfully) swaps the order of the 2 XRControllers.

