### PR TITLE
feat: expose utilities for headless button creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,25 @@ It supports an optional third parameter with options for filtering by handedness
 ```jsx
 useXREvent('squeeze', (event: XRControllerEvent) => ..., { handedness: 'left' | 'right' | 'none' })
 ```
+
+### Custom XRButton
+
+While you can customize XRButton, there's a way to shave off `react-dom` and customize it even more. For this there's a couple of low-level utilities of a headless xr button: `startSession`, `stopSession` and `toggleSession`.
+
+```jsx
+import { toggleSession } from '@react-three/xr'
+
+const handleClick = async () => {
+  const session = await toggleSession('immersive-vr')
+  if (session) {
+    button.innerText = 'Exit VR'
+  } else {
+    button.innerText = 'Enter VR'
+  }
+}
+
+const button = document.createElement('button')
+button.innerText = 'Enter VR'
+button.addEventListener('click', handleClick)
+document.appendChild(button)
+```

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -357,11 +357,12 @@ export const XRButton = React.forwardRef<HTMLButtonElement, XRButtonProps>(funct
       try {
         toggleSession(sessionMode, { sessionInit, enterOnly, exitOnly })
       } catch (e) {
-        if (onError && e instanceof Error) onErrorRef.current?.(e)
+        const onError = onErrorRef.current
+        if (onError && e instanceof Error) onError(e)
         else throw e
       }
     },
-    [onClick, sessionMode, sessionInit, enterOnly, exitOnly, onError, onErrorRef]
+    [onClick, sessionMode, sessionInit, enterOnly, exitOnly, onErrorRef]
   )
 
   return (

--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -280,32 +280,47 @@ const getSessionOptions = (
   return sessionInit
 }
 
-export const toggleSessionHeadless = async (
+export const startSession = async (sessionMode: XRSessionMode, sessionInit: XRButtonProps['sessionInit']) => {
+  const xrState = globalSessionStore.getState()
+
+  if (xrState.session) {
+    console.warn('@react-three/xr: session already started, please stop it first')
+    return
+  }
+
+  const options = getSessionOptions(xrState.referenceSpaceType, sessionInit)
+  const session = await navigator.xr!.requestSession(sessionMode, options)
+  xrState.set(() => ({ session }))
+  return session
+}
+
+export const stopSession = async () => {
+  const xrState = globalSessionStore.getState()
+
+  if (!xrState.session) {
+    console.warn('@react-three/xr: no session to stop, please start it first')
+    return
+  }
+
+  await xrState.session.end()
+  xrState.set({ session: null })
+}
+
+export const toggleSession = async (
   sessionMode: XRSessionMode,
-  { sessionInit, onError, enterOnly, exitOnly }: Pick<XRButtonProps, 'sessionInit' | 'onError' | 'enterOnly' | 'exitOnly'> = {}
+  { sessionInit, enterOnly, exitOnly }: Pick<XRButtonProps, 'sessionInit' | 'enterOnly' | 'exitOnly'> = {}
 ) => {
   const xrState = globalSessionStore.getState()
 
-  // Bail if button only configures exit/enter
+  // Bail if certain toggle way is disabled
   if (xrState.session && enterOnly) return
   if (!xrState.session && exitOnly) return
 
-  let session: XRSession | null = null
-
-  try {
-    // Exit/enter session
-    if (xrState.session) {
-      await xrState.session.end()
-    } else {
-      const options = getSessionOptions(xrState.referenceSpaceType, sessionInit)
-      session = await navigator.xr!.requestSession(sessionMode, options)
-    }
-
-    xrState.set(() => ({ session }))
-    return session
-  } catch (e) {
-    if (onError && e instanceof Error) onError(e)
-    else throw e
+  // Exit/enter session
+  if (xrState.session) {
+    return await stopSession()
+  } else {
+    return await startSession(sessionMode, sessionInit)
   }
 }
 
@@ -335,16 +350,22 @@ export const XRButton = React.forwardRef<HTMLButtonElement, XRButtonProps>(funct
     [status]
   )
 
-  const toggleSession = React.useCallback(
+  const handleButtonClick = React.useCallback(
     async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       onClick?.(event)
-      toggleSessionHeadless(sessionMode, { sessionInit, onError: onErrorRef.current, enterOnly, exitOnly })
+
+      try {
+        toggleSession(sessionMode, { sessionInit, enterOnly, exitOnly })
+      } catch (e) {
+        if (onError && e instanceof Error) onErrorRef.current?.(e)
+        else throw e
+      }
     },
-    [onClick, sessionMode, sessionInit, onErrorRef, enterOnly, exitOnly]
+    [onClick, sessionMode, sessionInit, enterOnly, exitOnly, onError, onErrorRef]
   )
 
   return (
-    <button {...props} ref={ref} onClick={status === 'unsupported' ? onClick : toggleSession}>
+    <button {...props} ref={ref} onClick={status === 'unsupported' ? onClick : handleButtonClick}>
       {typeof children === 'function' ? children(status) : children ?? label}
     </button>
   )


### PR DESCRIPTION
Our usecase is that we don't use `<VRButton />` because we don't use `react-dom` at all, but we still want to integrate with `react-xr` state and keep it in sync. Previously we just handled our own state, but that lead to a bunch of bugs when someone used `useXR` for the data that was out of sync. So I came with this utilities that allows to create your own headless button in any way you desire. @CodyJasonBennett what do you think?

- [x] api
- [x] docs