### PR TITLE
fix: vendor and fix XRControllerModelFactory

### DIFF
--- a/src/Controllers.tsx
+++ b/src/Controllers.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { XRControllerModelFactory } from 'three-stdlib'
 import { useFrame, Object3DNode, extend, createPortal } from '@react-three/fiber'
 import { useXR } from './XR'
 import { XRController } from './XRController'
 import { useIsomorphicLayoutEffect } from './utils'
+import { XRControllerModel, XRControllerModelFactory } from './XRControllerModelFactory'
+import { XRControllerEvent } from './XREvents'
 
 export interface RayProps extends Partial<JSX.IntrinsicElements['object3D']> {
   /** The XRController to attach the ray to */
@@ -46,9 +47,33 @@ export const Ray = React.forwardRef<THREE.Line, RayProps>(function Ray({ target,
 const modelFactory = new XRControllerModelFactory()
 
 class ControllerModel extends THREE.Group {
+  readonly target: XRController
+  readonly xrControllerModel: XRControllerModel
+
   constructor(target: XRController) {
     super()
-    this.add(modelFactory.createControllerModel(target.controller))
+    this.xrControllerModel = new XRControllerModel()
+    this.target = target
+    this.add(this.xrControllerModel)
+
+    this._onConnected = this._onConnected.bind(this)
+    this._onDisconnected = this._onDisconnected.bind(this)
+
+    this.target.controller.addEventListener('connected', this._onConnected)
+    this.target.controller.addEventListener('disconnected', this._onDisconnected)
+  }
+
+  private _onConnected(event: XRControllerEvent) {
+    modelFactory.initializeControllerModel(this.xrControllerModel, event)
+  }
+
+  private _onDisconnected(_event: XRControllerEvent) {
+    this.xrControllerModel.disconnect()
+  }
+
+  dispose() {
+    this.target.controller.removeEventListener('connected', this._onConnected)
+    this.target.controller.removeEventListener('disconnected', this._onDisconnected)
   }
 }
 

--- a/src/XRControllerModelFactory.ts
+++ b/src/XRControllerModelFactory.ts
@@ -1,0 +1,249 @@
+import { Mesh, Object3D, SphereGeometry, MeshBasicMaterial } from 'three'
+import type { Texture } from 'three'
+import { fetchProfile, GLTFLoader, MotionController, MotionControllerConstants } from 'three-stdlib'
+
+const DEFAULT_PROFILES_PATH = 'https://cdn.jsdelivr.net/npm/@webxr-input-profiles/assets@1.0/dist/profiles'
+const DEFAULT_PROFILE = 'generic-trigger'
+
+const applyEnvironmentMap = (envMap: Texture, obj: Object3D): void => {
+  obj.traverse((child) => {
+    if (child instanceof Mesh && 'envMap' in child.material) {
+      child.material.envMap = envMap
+      child.material.needsUpdate = true
+    }
+  })
+}
+
+export class XRControllerModel extends Object3D {
+  envMap: Texture | null
+  motionController: MotionController | null
+  scene: Object3D | null
+
+  constructor() {
+    super()
+
+    this.motionController = null
+    this.envMap = null
+    this.scene = null
+  }
+
+  setEnvironmentMap(envMap: Texture): XRControllerModel {
+    if (this.envMap == envMap) {
+      return this
+    }
+
+    this.envMap = envMap
+    applyEnvironmentMap(this.envMap, this)
+
+    return this
+  }
+
+  connectModel(scene: Object3D): void {
+    if (!this.motionController) {
+      console.warn('scene tried to add, but no motion controller')
+      return
+    }
+
+    this.scene = scene
+    addAssetSceneToControllerModel(this, scene)
+    this.dispatchEvent({
+      type: 'modelconnected',
+      data: scene
+    })
+  }
+
+  connectMotionController(motionController: MotionController): void {
+    this.motionController = motionController
+    this.dispatchEvent({
+      type: 'motionconnected',
+      data: motionController
+    })
+  }
+
+  /**
+   * Polls data from the XRInputSource and updates the model's components to match
+   * the real world data
+   */
+  updateMatrixWorld(force: boolean): void {
+    super.updateMatrixWorld(force)
+
+    if (!this.motionController) return
+
+    // Cause the MotionController to poll the Gamepad for data
+    this.motionController.updateFromGamepad()
+
+    // Update the 3D model to reflect the button, thumbstick, and touchpad state
+    Object.values(this.motionController.components).forEach((component) => {
+      // Update node data based on the visual responses' current states
+      Object.values(component.visualResponses).forEach((visualResponse) => {
+        const { valueNode, minNode, maxNode, value, valueNodeProperty } = visualResponse
+
+        // Skip if the visual response node is not found. No error is needed,
+        // because it will have been reported at load time.
+        if (!valueNode) return
+
+        // Calculate the new properties based on the weight supplied
+        if (valueNodeProperty === MotionControllerConstants.VisualResponseProperty.VISIBILITY && typeof value === 'boolean') {
+          valueNode.visible = value
+        } else if (
+          valueNodeProperty === MotionControllerConstants.VisualResponseProperty.TRANSFORM &&
+          minNode &&
+          maxNode &&
+          typeof value === 'number'
+        ) {
+          valueNode.quaternion.slerpQuaternions(minNode.quaternion, maxNode.quaternion, value)
+
+          valueNode.position.lerpVectors(minNode.position, maxNode.position, value)
+        }
+      })
+    })
+  }
+
+  disconnect(): void {
+    this.dispatchEvent({
+      type: 'motiondisconnected',
+      data: this.motionController
+    })
+    this.dispatchEvent({
+      type: 'modeldisconnected',
+      data: this.scene
+    })
+    this.motionController = null
+    if (this.scene) {
+      this.remove(this.scene)
+    }
+    this.scene = null
+  }
+
+  dispose(): void {
+    this.disconnect()
+  }
+}
+
+/**
+ * Walks the model's tree to find the nodes needed to animate the components and
+ * saves them to the motionContoller components for use in the frame loop. When
+ * touchpads are found, attaches a touch dot to them.
+ */
+function findNodes(motionController: MotionController, scene: Object3D): void {
+  // Loop through the components and find the nodes needed for each components' visual responses
+  Object.values(motionController.components).forEach((component) => {
+    const { type, touchPointNodeName, visualResponses } = component
+
+    if (type === MotionControllerConstants.ComponentType.TOUCHPAD && touchPointNodeName) {
+      component.touchPointNode = scene.getObjectByName(touchPointNodeName)
+      if (component.touchPointNode) {
+        // Attach a touch dot to the touchpad.
+        const sphereGeometry = new SphereGeometry(0.001)
+        const material = new MeshBasicMaterial({ color: 0x0000ff })
+        const sphere = new Mesh(sphereGeometry, material)
+        component.touchPointNode.add(sphere)
+      } else {
+        console.warn(`Could not find touch dot, ${component.touchPointNodeName}, in touchpad component ${component.id}`)
+      }
+    }
+
+    // Loop through all the visual responses to be applied to this component
+    Object.values(visualResponses).forEach((visualResponse) => {
+      const { valueNodeName, minNodeName, maxNodeName, valueNodeProperty } = visualResponse
+
+      // If animating a transform, find the two nodes to be interpolated between.
+      if (valueNodeProperty === MotionControllerConstants.VisualResponseProperty.TRANSFORM && minNodeName && maxNodeName) {
+        visualResponse.minNode = scene.getObjectByName(minNodeName)
+        visualResponse.maxNode = scene.getObjectByName(maxNodeName)
+
+        // If the extents cannot be found, skip this animation
+        if (!visualResponse.minNode) {
+          console.warn(`Could not find ${minNodeName} in the model`)
+          return
+        }
+
+        if (!visualResponse.maxNode) {
+          console.warn(`Could not find ${maxNodeName} in the model`)
+          return
+        }
+      }
+
+      // If the target node cannot be found, skip this animation
+      visualResponse.valueNode = scene.getObjectByName(valueNodeName)
+      if (!visualResponse.valueNode) {
+        console.warn(`Could not find ${valueNodeName} in the model`)
+      }
+    })
+  })
+}
+
+function addAssetSceneToControllerModel(controllerModel: XRControllerModel, scene: Object3D): void {
+  // Find the nodes needed for animation and cache them on the motionController.
+  findNodes(controllerModel.motionController!, scene)
+
+  // Apply any environment map that the mesh already has set.
+  if (controllerModel.envMap) {
+    applyEnvironmentMap(controllerModel.envMap, scene)
+  }
+
+  // Add the glTF scene to the controllerModel.
+  controllerModel.add(scene)
+}
+
+export class XRControllerModelFactory {
+  gltfLoader: GLTFLoader
+  path: string
+  private _assetCache: Record<string, { scene: Object3D } | undefined>
+  constructor(gltfLoader: GLTFLoader | null = null, path = DEFAULT_PROFILES_PATH) {
+    this.gltfLoader = gltfLoader ?? new GLTFLoader()
+    this.path = path
+    this._assetCache = {}
+  }
+
+  initializeControllerModel(controllerModel: XRControllerModel, event: any): void {
+    const xrInputSource = event.data
+
+    if (xrInputSource.targetRayMode !== 'tracked-pointer' || !xrInputSource.gamepad) return
+
+    fetchProfile(xrInputSource, this.path, DEFAULT_PROFILE)
+      .then(({ profile, assetPath }) => {
+        if (!assetPath) {
+          throw new Error('no asset path')
+        }
+
+        const motionController = new MotionController(xrInputSource, profile, assetPath)
+        controllerModel.connectMotionController(motionController)
+
+        const assetUrl = motionController.assetUrl
+
+        const cachedAsset = this._assetCache[assetUrl]
+        if (cachedAsset) {
+          const scene = cachedAsset.scene.clone()
+
+          controllerModel.connectModel(scene)
+        } else {
+          if (!this.gltfLoader) {
+            throw new Error('GLTFLoader not set.')
+          }
+
+          this.gltfLoader.setPath('')
+          this.gltfLoader.load(
+            assetUrl,
+            (asset: { scene: Object3D }) => {
+              if (!controllerModel.motionController) {
+                console.warn('motionController gone while gltf load, bailing...')
+                return
+              }
+
+              this._assetCache[assetUrl] = asset
+              const scene = asset.scene.clone()
+              controllerModel.connectModel(scene)
+            },
+            undefined,
+            () => {
+              throw new Error(`Asset ${assetUrl} missing or malformed.`)
+            }
+          )
+        }
+      })
+      .catch((err) => {
+        console.warn(err)
+      })
+  }
+}


### PR DESCRIPTION
Following the [discussion](https://discord.com/channels/740090768164651008/749648291049898074/1070374102642213055) I vendored `XRControllerModelFactory` to `react-xr` along with some changes inside.

The main point of this is to fix problems with connecting/disconnecting different or same controllers, turns out webxr world is crazy full of quirks (who'd have thought). It all started in https://github.com/pmndrs/three-stdlib/pull/214: there I tried to fix a problem when you connect and disconnect controllers and it doesn't unsubscribe from `connected` event. Thing is, in three, `WebXRController` are only created twice and never recreated, but they spew out `connected/disconnected` events. Connecting and disconnecting same or different controllers before this fix would result in ever more increasing `connected` event listeners each trying to load and add the scene. I've added the unsubscription fix, but it shot me in the foot in the most weird way. Turns out, SteamVR is connecting controllers in a peculiar way: it first dispatches `inputsourceschange` event with `added: [some input source data]`, then immediately `inputsourceschange` with `removed: [the input source that was just added]` and then inputsourceschange` with `added: [proper input source]`. And with the fix, it just unsubscribes from `connected` and never has a chance to resubscribe (cause it's kind of the same controller). With all that in mind I refactored `XRControllerModelFactory`, `XRControllerModel` and `ControllerModel` into somewhat cohesive picture that works with all this quirks. We tested it on multiple devies including Oculus Go, Quest 1, 2 and Pro, Rift S, Valve Index, Vive Cosmos and the others and we've yet to find more problems with it, this works robust. I don't really like the way it looks now, because logic is bit scattered all over the place, but it's no worse than it was before IMO

The other thing I did in this PR is to add a few events that `XRControllerModel` now dispatches, namely, `modelconnected/disconnected` and `motionconnected/disconnected`. They're not currently used in `react-xr` code, it's only used in our own app code to do 2 things:

1. Analyze data from `MotionController` to dispatch events such as button press/thumbstick move/etc. This is directly applicable to `react-xr` and I plan to expose it as an additional api surface to `Interactive`
2. Add more 3d stuff to the controller model, we add a tutorial that shows which button does what. Don't see a clear way for `react-xr` to take advantage of it right now, except for examples maybe

I'm willing to move these events dispatch to a separate PR if it's any problem