### PR TITLE
Support corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-three/xr",
   "version": "5.2.0",
+  "packageManager": "yarn@1.22.19",
   "description": "React components and hooks for creating VR/AR applications with react-three-fiber",
   "keywords": [
     "xr",


### PR DESCRIPTION
We recently started using corepack and yarn v3 and packages that doesn't have `pakcageManager` field but use `yarn` become a bit of a nuisance since it tries to use new one. This fixes it for corepack users