### PR TITLE
fix: make events pass full list of intersections

### DIFF
--- a/src/Interactions.tsx
+++ b/src/Interactions.tsx
@@ -64,10 +64,6 @@ export function InteractionManager({ children }: { children: React.ReactNode }) 
         // https://github.com/mrdoob/three.js/issues/16031
         // Allow custom userland intersect sort order
         intersections = events.filter(intersections, get())
-      } else {
-        // Otherwise, filter to first hit
-        const hit = intersections.find((i) => i?.object)
-        if (hit) intersections = [hit]
       }
 
       for (const intersection of intersections) {
@@ -110,7 +106,7 @@ export function InteractionManager({ children }: { children: React.ReactNode }) 
   const triggerEvent = React.useCallback(
     (interaction: XRInteractionType) => (e: XREvent<XRControllerEvent>) => {
       const hovering = hoverState[e.target.inputSource.handedness]
-      const intersections = Array.from(new Set(hovering.values()))
+      const intersections = intersect(e.target.controller)
 
       interactions.forEach((handlers, object) => {
         if (hovering.has(object)) {
@@ -132,7 +128,7 @@ export function InteractionManager({ children }: { children: React.ReactNode }) 
         }
       })
     },
-    [hoverState, interactions]
+    [hoverState, interactions, intersect]
   )
 
   useXREvent('select', triggerEvent('onSelect'))


### PR DESCRIPTION
This PR changes onMove and Select events to return the full list of intersections in the event.

Related issue https://github.com/pmndrs/react-xr/issues/258