### PR TITLE
fix: switch to type=module for Webpack <5

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "dist/*",
     "src/*"
   ],
+  "type": "module",
   "types": "dist/index.d.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "sideEffects": false,
   "devDependencies": {
     "@react-three/drei": "^9.13.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
       "@react-three/xr": ["./src"]
     }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.*", "src/mocks/**"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,5 @@
       "@react-three/xr": ["./src"]
     }
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.*", "src/mocks/**"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
Fixes #264 by preferring the `.js` extension for ESM. I do not specify `package#exports` as Codesandbox resolution is a bit unstable there as of late.