### PR TITLE
fix(Teleport): sync reference space with new sessions

### DIFF
--- a/src/Teleportation.tsx
+++ b/src/Teleportation.tsx
@@ -19,13 +19,13 @@ export function useTeleportation(): TeleportCallback {
   const teleportReferenceSpace = React.useRef<XRReferenceSpace | null>(null)
 
   useFrame((state, _, xrFrame) => {
-    frame.current = xrFrame
-
-    const referenceSpace = state.gl.xr.getReferenceSpace()
-    baseReferenceSpace.current ??= referenceSpace
+    if (frame.current !== xrFrame) {
+      frame.current = xrFrame
+      baseReferenceSpace.current = state.gl.xr.getReferenceSpace()
+    }
 
     const teleportOffset = teleportReferenceSpace.current
-    if (teleportOffset && referenceSpace !== teleportOffset) {
+    if (teleportOffset && baseReferenceSpace.current !== teleportOffset) {
       state.gl.xr.setReferenceSpace(teleportOffset)
     }
   })


### PR DESCRIPTION
Fixes #289 where `useTeleportation` would hold onto old reference spaces which are no longer valid in a new session.