### PR TITLE
fix(examples): fix codesandbox build

### DIFF
--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -1,15 +1,9 @@
 import { defineConfig } from 'vite'
-import path from 'node:path'
 import react from '@vitejs/plugin-react'
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  resolve: {
-    alias: {
-      '@react-three/xr': path.resolve(__dirname, '../src')
-    }
-  },
   assetsInclude: ['**/*.hdr', '**/*.gltf'],
   plugins: [react(), vanillaExtractPlugin()]
 })


### PR DESCRIPTION
Hey, @CodyJasonBennett , I saw that you've brought back path resolve in `examples/vite.config.ts`. I removed it on purpose so the codesandbox CI would work (it used to, but now it doesn't, not sure why). My idea is that examples are supposed to be run from the root with `yarn dev`, not from `examples` folder, and I highlighted it in https://github.com/pmndrs/react-xr/blob/master/CONTRIBUTING.md#run-locally for the newcomers. I apologize for not being clear enough in my PRs.

So, like, root vite.config will be responsible for local runs and examples/vite.config will be for codesandbox CI.

Example of codesandbox not working may be found in this PR, for instance
https://github.com/pmndrs/react-xr/pull/294
https://codesandbox.io/p/sandbox/examples-j88rj5