### PR TITLE
fix: add controller immediately to available controllers if inputSource exists already

### DIFF
--- a/src/XR.tsx
+++ b/src/XR.tsx
@@ -71,11 +71,18 @@ function XRManager({
   const onSessionEndRef = useCallbackRef(onSessionEnd)
   const onVisibilityChangeRef = useCallbackRef(onVisibilityChange)
   const onInputSourcesChangeRef = useCallbackRef(onInputSourcesChange)
-
   useIsomorphicLayoutEffect(() => {
     const handlers = [0, 1].map((id) => {
       const target = new XRController(id, gl)
-      const onConnected = () => set((state) => ({ controllers: [...state.controllers, target] }))
+      const inputSource = session?.inputSources[id]
+      // If the input source is already connected, add it to the controllers list
+      if (inputSource) {
+        target.visible = true
+        target.inputSource = inputSource
+        set((state) => ({ controllers: [...state.controllers, target] }))
+      }
+
+      const onConnected = () => set((state) => ({ controllers: [...state.controllers.filter((it) => it !== target), target] }))
       const onDisconnected = () => set((state) => ({ controllers: state.controllers.filter((it) => it !== target) }))
 
       target.addEventListener('connected', onConnected)


### PR DESCRIPTION
Currently when starting up an application with Oculus Quest 3, the controllers don't come up until you make them disconnect and then reconnect (this means spamming the oculus button a couple of times and returning to the app), which then causes the `connected` eventListener to trigger.

Crude fix I found working for my case was to check during handler if `inputSource` already exists for specific `id`, and then just immediately add to the list of working controllers.