### PR TITLE
fix: The IfFacingCamera component was never hooked up

### DIFF
--- a/packages/react/xr/src/guard/facing-camera.tsx
+++ b/packages/react/xr/src/guard/facing-camera.tsx
@@ -61,5 +61,5 @@ export function IfFacingCamera({ children, direction, angle = Math.PI / 2 }: Fac
   const ref = useRef<Group>(null)
   const [show, setShow] = useState(false)
   useIsFacingCamera(ref, setShow, direction, angle)
-  return show ? <>{children}</> : null
+  return <group ref={ref}>{show ? children : null}</group>
 }


### PR DESCRIPTION
# Changes
- Added a `<group>` to wrap around the children that a ref can be attached to.


> [!WARNING]
> This change may be breaking as it now inserts a group around the children where nothing was rendering before. Though as the component was completely broken before, I doubt anybody is actually using it. 