### PR TITLE
feat: improve MapHandles wheel/trackpad gestures

### DIFF
--- a/examples/map-handles/index.css
+++ b/examples/map-handles/index.css
@@ -1,0 +1,11 @@
+body {
+  margin: 0;
+  width: 100dvw;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+#root {
+  width: 100%;
+  height: 100%;
+}

--- a/examples/map-handles/index.html
+++ b/examples/map-handles/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <title>MapHandles Example</title>
+    <link rel="stylesheet" href="./index.css" />
+    <script async type="module" src="./index.tsx"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/map-handles/index.tsx
+++ b/examples/map-handles/index.tsx
@@ -1,0 +1,22 @@
+import { createRoot } from 'react-dom/client'
+import { Canvas } from '@react-three/fiber'
+import { MapHandles, useDisableGestures } from '@react-three/handle'
+import '@react-three/handle/disable-gestures.css'
+import { noEvents, PointerEvents } from '@react-three/xr'
+
+function App() {
+  useDisableGestures()
+  return (
+    <Canvas camera={{ position: [0, 5, 5] }} events={noEvents}>
+      <PointerEvents />
+      <MapHandles damping />
+      <gridHelper args={[20, 20]} />
+      <mesh position={[0, 0.5, 0]}>
+        <boxGeometry />
+        <meshNormalMaterial />
+      </mesh>
+    </Canvas>
+  )
+}
+
+createRoot(document.getElementById('root')!).render(<App />)

--- a/examples/map-handles/package.json
+++ b/examples/map-handles/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "@pmndrs/pointer-events": "workspace:~",
+    "@react-three/handle": "workspace:~",
+    "@react-three/xr": "workspace:~"
+  },
+  "scripts": {
+    "dev": "vite --host"
+  }
+}

--- a/packages/handle/package.json
+++ b/packages/handle/package.json
@@ -7,7 +7,7 @@
   "version": "0.0.0",
   "scripts": {
     "build": "tsc",
-    "test": "mocha ./tests/*.spec.ts",
+    "test": "vitest run",
     "check:prettier": "prettier --check src",
     "check:eslint": "eslint \"src/**/*.{ts,tsx}\"",
     "fix:prettier": "prettier --write src",
@@ -34,6 +34,12 @@
   "dependencies": {
     "@pmndrs/pointer-events": "workspace:~",
     "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "playwright": "^1.40.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "three": "*"
   },
   "files": [
     "dist"

--- a/packages/handle/src/screen/map.ts
+++ b/packages/handle/src/screen/map.ts
@@ -16,23 +16,15 @@ import { ZoomScreenHandleStore } from './zoom.js'
 
 const vectorHelper = new Vector3()
 
-/** Default speed multiplier for vertical scroll → zoom */
 const DEFAULT_ZOOM_SPEED = 0.01
-/** Default speed multiplier for horizontal scroll → yaw rotation */
 const DEFAULT_YAW_SPEED = 0.002
-/** Default speed multiplier for pinch (ctrl+scroll) → pitch rotation */
 const DEFAULT_PITCH_SPEED = 0.02
-/** Default speed multiplier for shift+scroll → pan */
 const DEFAULT_PAN_SPEED = 0.0005
 
 export interface MapHandlesWheelOptions {
-  /** Vertical scroll zoom speed, or false to disable. Default: 0.01 */
   zoom?: number | false
-  /** Horizontal scroll yaw speed, or false to disable. Default: 0.002 */
   yaw?: number | false
-  /** Ctrl+scroll pitch speed, or false to disable. Default: 0.02 */
   pitch?: number | false
-  /** Shift+scroll pan speed, or false to disable. Default: 0.0005 */
   pan?: number | false
 }
 
@@ -120,9 +112,6 @@ export class MapHandles {
     this.updateDamping(deltaTime)
   }
 
-  /**
-   * Binds wheel event handling for scroll/pinch gestures.
-   */
   bindWheel(scene: Scene) {
     const voidObject = getVoidObject(scene)
     const onWheel = this.onWheel.bind(this)

--- a/packages/handle/src/screen/map.ts
+++ b/packages/handle/src/screen/map.ts
@@ -1,3 +1,4 @@
+import { getVoidObject, WheelEvent } from '@pmndrs/pointer-events'
 import { PerspectiveCamera, OrthographicCamera, Scene, Vector3 } from 'three'
 import { clamp } from 'three/src/math/MathUtils.js'
 import { StoreApi } from 'zustand'
@@ -15,6 +16,26 @@ import { ZoomScreenHandleStore } from './zoom.js'
 
 const vectorHelper = new Vector3()
 
+/** Default speed multiplier for vertical scroll → zoom */
+const DEFAULT_ZOOM_SPEED = 0.01
+/** Default speed multiplier for horizontal scroll → yaw rotation */
+const DEFAULT_YAW_SPEED = 0.002
+/** Default speed multiplier for pinch (ctrl+scroll) → pitch rotation */
+const DEFAULT_PITCH_SPEED = 0.02
+/** Default speed multiplier for shift+scroll → pan */
+const DEFAULT_PAN_SPEED = 0.0005
+
+export interface MapHandlesWheelOptions {
+  /** Vertical scroll zoom speed, or false to disable. Default: 0.01 */
+  zoom?: number | false
+  /** Horizontal scroll yaw speed, or false to disable. Default: 0.002 */
+  yaw?: number | false
+  /** Ctrl+scroll pitch speed, or false to disable. Default: 0.02 */
+  pitch?: number | false
+  /** Shift+scroll pan speed, or false to disable. Default: 0.0005 */
+  pan?: number | false
+}
+
 export function defaultMapHandlesScreenCameraApply(
   update: Partial<ScreenCameraState>,
   store: StoreApi<ScreenCameraState>,
@@ -25,6 +46,12 @@ export function defaultMapHandlesScreenCameraApply(
   store.setState(update)
 }
 
+/**
+ * Map-style camera controls with pan, rotate, and zoom.
+ *
+ * To prevent browser gestures from interfering, set `touch-action: none`
+ * on the canvas container for touch devices.
+ */
 export class MapHandles {
   public readonly rotate: RotateScreenHandleStore
   public readonly pan: PanScreenHandleStore
@@ -32,6 +59,7 @@ export class MapHandles {
 
   private readonly store: StoreApi<ScreenCameraStateAndFunctions>
   private readonly getCamera: () => PerspectiveCamera | OrthographicCamera
+  private readonly wheelOptions: Required<MapHandlesWheelOptions>
   private updateDamping: (deltaTime: number) => void
   private damping: boolean | number = false
 
@@ -39,6 +67,7 @@ export class MapHandles {
     canvas: HTMLCanvasElement,
     camera: (() => PerspectiveCamera | OrthographicCamera) | PerspectiveCamera | OrthographicCamera,
     store?: StoreApi<ScreenCameraStateAndFunctions>,
+    wheel?: MapHandlesWheelOptions,
   ) {
     if (store == null) {
       store = createScreenCameraStore()
@@ -47,6 +76,12 @@ export class MapHandles {
     }
     this.store = store
     this.getCamera = typeof camera === 'function' ? camera : () => camera
+    this.wheelOptions = {
+      zoom: wheel?.zoom ?? DEFAULT_ZOOM_SPEED,
+      yaw: wheel?.yaw ?? DEFAULT_YAW_SPEED,
+      pitch: wheel?.pitch ?? DEFAULT_PITCH_SPEED,
+      pan: wheel?.pan ?? DEFAULT_PAN_SPEED,
+    }
     this.updateDamping = applyDampedScreenCameraState(store, this.getCamera, () => this.damping)
     this.rotate = new RotateScreenHandleStore(
       store,
@@ -63,7 +98,15 @@ export class MapHandles {
       1,
       'xz',
     )
-    this.zoom = new ZoomScreenHandleStore(store, this.getCamera, undefined, defaultMapHandlesScreenCameraApply)
+    this.zoom = new ZoomScreenHandleStore(
+      store,
+      this.getCamera,
+      undefined,
+      defaultMapHandlesScreenCameraApply,
+      undefined,
+      undefined,
+      true, // skipWheel - MapHandles handles wheel events
+    )
   }
 
   getStore() {
@@ -77,10 +120,90 @@ export class MapHandles {
     this.updateDamping(deltaTime)
   }
 
+  /**
+   * Binds wheel event handling for scroll/pinch gestures.
+   */
+  bindWheel(scene: Scene) {
+    const voidObject = getVoidObject(scene)
+    const onWheel = this.onWheel.bind(this)
+    voidObject.addEventListener('wheel', onWheel)
+    return () => voidObject.removeEventListener('wheel', onWheel)
+  }
+
+  /**
+   * Handles wheel events for trackpad/mouse gestures:
+   * - Vertical scroll → zoom
+   * - Horizontal scroll → yaw (rotate)
+   * - Ctrl + scroll (pinch) → pitch (tilt angle)
+   * - Shift + scroll → pan
+   *
+   * Note: There's no reliable cross-browser way to distinguish mouse wheel from trackpad.
+   * @see https://github.com/w3c/uievents/issues/337
+   */
+  private onWheel(e: WheelEvent) {
+    const { deltaX, deltaY, ctrlKey, shiftKey } = e
+    if (Math.abs(deltaX) < 1 && Math.abs(deltaY) < 1) return
+
+    const state = this.store.getState()
+
+    if (ctrlKey && this.wheelOptions.pitch !== false) {
+      ;(e.nativeEvent as globalThis.WheelEvent).preventDefault?.()
+      this.applyPitch(state, deltaY)
+    } else if (shiftKey && this.wheelOptions.pan !== false) {
+      ;(e.nativeEvent as globalThis.WheelEvent).preventDefault?.()
+      this.applyPan(state, deltaX, deltaY)
+    } else if (this.wheelOptions.zoom !== false || this.wheelOptions.yaw !== false) {
+      ;(e.nativeEvent as globalThis.WheelEvent).preventDefault?.()
+      this.applyZoomAndYaw(state, deltaX, deltaY)
+    }
+  }
+
+  private applyPan(state: ScreenCameraStateAndFunctions, deltaX: number, deltaY: number) {
+    const speed = this.wheelOptions.pan as number
+    const panX = deltaX * speed * state.distance
+    const panZ = deltaY * speed * state.distance
+    const cosYaw = Math.cos(state.yaw)
+    const sinYaw = Math.sin(state.yaw)
+    const [ox, oy, oz] = state.origin
+    defaultMapHandlesScreenCameraApply(
+      {
+        origin: [ox + panX * cosYaw + panZ * sinYaw, oy, oz - panX * sinYaw + panZ * cosYaw],
+      },
+      this.store,
+    )
+  }
+
+  private applyPitch(state: ScreenCameraStateAndFunctions, deltaY: number) {
+    const speed = this.wheelOptions.pitch as number
+    defaultMapHandlesScreenCameraApply(
+      {
+        pitch: state.pitch - deltaY * speed,
+      },
+      this.store,
+    )
+  }
+
+  private applyZoomAndYaw(state: ScreenCameraStateAndFunctions, deltaX: number, deltaY: number) {
+    const update: Partial<ScreenCameraState> = {}
+    const { yaw, zoom } = this.wheelOptions
+    if (Math.abs(deltaX) >= 1 && yaw !== false) {
+      update.yaw = state.yaw - deltaX * yaw
+    }
+    if (Math.abs(deltaY) >= 1 && zoom !== false) {
+      update.distance = state.distance / Math.pow(0.95, deltaY * zoom)
+    }
+    defaultMapHandlesScreenCameraApply(update, this.store)
+  }
+
   bind(scene: Scene, damping: boolean | number = false) {
     const unbindRotate = this.rotate.bind(scene)
     const unbindPan = this.pan.bind(scene)
     const unbindZoom = this.zoom.bind(scene)
+
+    const voidObject = getVoidObject(scene)
+    const onWheel = this.onWheel.bind(this)
+    voidObject.addEventListener('wheel', onWheel)
+
     let unsubscribeCamera: (() => void) | undefined
     if (damping === false) {
       unsubscribeCamera = applyScreenCameraState(this.store, this.getCamera)
@@ -90,6 +213,7 @@ export class MapHandles {
       unbindRotate()
       unbindPan()
       unbindZoom()
+      voidObject.removeEventListener('wheel', onWheel)
       unsubscribeCamera?.()
     }
   }

--- a/packages/handle/tests/browser/index.css
+++ b/packages/handle/tests/browser/index.css
@@ -1,0 +1,13 @@
+body {
+  margin: 0;
+  overflow: hidden;
+  touch-action: none;
+  overscroll-behavior: none;
+  height: 100vh;
+  width: 100vw;
+}
+
+#canvas {
+  position: absolute;
+  inset: 0;
+}

--- a/packages/handle/tests/browser/index.html
+++ b/packages/handle/tests/browser/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MapHandles Test</title>
+    <link rel="stylesheet" href="./index.css" />
+  </head>
+  <body>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>

--- a/packages/handle/tests/browser/index.ts
+++ b/packages/handle/tests/browser/index.ts
@@ -1,5 +1,5 @@
-import { Scene, PerspectiveCamera, WebGLRenderer, GridHelper } from 'three'
 import { forwardHtmlEvents } from '@pmndrs/pointer-events'
+import { Scene, PerspectiveCamera, WebGLRenderer, GridHelper } from 'three'
 import { MapHandles, MapHandlesWheelOptions } from '../../src/screen/map.js'
 
 // Parse wheel options from URL params

--- a/packages/handle/tests/browser/index.ts
+++ b/packages/handle/tests/browser/index.ts
@@ -1,0 +1,81 @@
+import { Scene, PerspectiveCamera, WebGLRenderer, GridHelper } from 'three'
+import { forwardHtmlEvents } from '@pmndrs/pointer-events'
+import { MapHandles, MapHandlesWheelOptions } from '../../src/screen/map.js'
+
+// Parse wheel options from URL params
+function getWheelOptionsFromURL(): MapHandlesWheelOptions | undefined {
+  const params = new URLSearchParams(window.location.search)
+  const options: MapHandlesWheelOptions = {}
+  let hasOptions = false
+
+  for (const key of ['zoom', 'yaw', 'pitch', 'pan'] as const) {
+    const value = params.get(key)
+    if (value !== null) {
+      hasOptions = true
+      options[key] = value === 'false' ? false : parseFloat(value)
+    }
+  }
+
+  return hasOptions ? options : undefined
+}
+
+const scene = new Scene()
+const canvas = document.getElementById('canvas') as HTMLCanvasElement
+const camera = new PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000)
+camera.position.set(0, 5, 5)
+camera.lookAt(0, 0, 0)
+
+const renderer = new WebGLRenderer({ antialias: true, canvas })
+renderer.setSize(window.innerWidth, window.innerHeight)
+
+// Setup pointer events forwarding
+const { update: updatePointerEvents } = forwardHtmlEvents(canvas, () => camera, scene)
+
+// Setup MapHandles with optional wheel config from URL
+const wheelOptions = getWheelOptionsFromURL()
+const mapHandles = new MapHandles(canvas, camera, undefined, wheelOptions)
+const unbind = mapHandles.bind(scene)
+
+// Add grid for visual reference
+scene.add(new GridHelper(20, 20))
+
+// Expose state for testing
+declare global {
+  interface Window {
+    getState: () => {
+      yaw: number
+      pitch: number
+      distance: number
+      origin: readonly [number, number, number]
+    }
+  }
+}
+
+window.getState = () => {
+  const state = mapHandles.getStore().getState()
+  return {
+    yaw: state.yaw,
+    pitch: state.pitch,
+    distance: state.distance,
+    origin: state.origin,
+  }
+}
+
+// Log state changes for debugging
+mapHandles.getStore().subscribe((state) => {
+  console.log(
+    '[state]',
+    JSON.stringify({
+      yaw: state.yaw.toFixed(4),
+      pitch: state.pitch.toFixed(4),
+      distance: state.distance.toFixed(4),
+      origin: state.origin.map((v) => v.toFixed(4)),
+    }),
+  )
+})
+
+renderer.setAnimationLoop((time) => {
+  updatePointerEvents()
+  mapHandles.update(16) // ~60fps delta
+  renderer.render(scene, camera)
+})

--- a/packages/handle/tests/map-handles-wheel.spec.ts
+++ b/packages/handle/tests/map-handles-wheel.spec.ts
@@ -1,7 +1,7 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { resolve } from 'path'
 import { Browser, BrowserContext, Page, chromium, devices } from 'playwright'
 import { createServer, ViteDevServer } from 'vite'
-import { resolve } from 'path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 let browser: Browser
 let server: ViteDevServer

--- a/packages/handle/tests/map-handles-wheel.spec.ts
+++ b/packages/handle/tests/map-handles-wheel.spec.ts
@@ -1,0 +1,221 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Browser, BrowserContext, Page, chromium, devices } from 'playwright'
+import { createServer, ViteDevServer } from 'vite'
+import { resolve } from 'path'
+
+let browser: Browser
+let server: ViteDevServer
+
+beforeAll(async () => {
+  browser = await chromium.launch({ headless: true })
+  server = await createServer({
+    configFile: false,
+    root: resolve(__dirname, 'browser'),
+    server: { port: 3456 },
+  })
+  await server.listen()
+})
+
+afterAll(async () => {
+  await browser.close()
+  await server.close()
+})
+
+describe('MapHandles wheel behavior', () => {
+  let context: BrowserContext
+  let page: Page
+  let width: number
+  let height: number
+
+  beforeAll(async () => {
+    context = await browser.newContext(devices['Desktop Chrome'])
+    const viewport = devices['Desktop Chrome'].viewport!
+    width = viewport.width
+    height = viewport.height
+    page = await context.newPage()
+    await page.goto('http://localhost:3456')
+    // Wait for scene to initialize
+    await page.waitForFunction(() => typeof window.getState === 'function')
+  })
+
+  afterAll(async () => {
+    await context.close()
+  })
+
+  async function getState() {
+    return page.evaluate(() => window.getState())
+  }
+
+  async function dispatchWheel(options: { deltaX?: number; deltaY?: number; ctrlKey?: boolean; shiftKey?: boolean }) {
+    await page.mouse.move(width / 2, height / 2)
+    await page.evaluate((opts) => {
+      const event = new WheelEvent('wheel', {
+        deltaX: opts.deltaX ?? 0,
+        deltaY: opts.deltaY ?? 0,
+        ctrlKey: opts.ctrlKey ?? false,
+        shiftKey: opts.shiftKey ?? false,
+        bubbles: true,
+        cancelable: true,
+      })
+      document.getElementById('canvas')!.dispatchEvent(event)
+    }, options)
+    // Wait for state update
+    await page.waitForTimeout(50)
+  }
+
+  it('vertical scroll should zoom (change distance)', async () => {
+    const before = await getState()
+    await dispatchWheel({ deltaY: 100 })
+    const after = await getState()
+
+    expect(after.distance).not.toBe(before.distance)
+    expect(after.yaw).toBe(before.yaw)
+    expect(after.pitch).toBe(before.pitch)
+  })
+
+  it('horizontal scroll should rotate yaw', async () => {
+    const before = await getState()
+    await dispatchWheel({ deltaX: 100 })
+    const after = await getState()
+
+    expect(after.yaw).not.toBe(before.yaw)
+    expect(after.distance).toBe(before.distance)
+    expect(after.pitch).toBe(before.pitch)
+  })
+
+  it('ctrl + scroll should change pitch', async () => {
+    const before = await getState()
+    await dispatchWheel({ deltaY: 100, ctrlKey: true })
+    const after = await getState()
+
+    expect(after.pitch).not.toBe(before.pitch)
+    expect(after.distance).toBe(before.distance)
+    expect(after.yaw).toBe(before.yaw)
+  })
+
+  it('shift + scroll should pan (change origin)', async () => {
+    const before = await getState()
+    await dispatchWheel({ deltaY: 100, shiftKey: true })
+    const after = await getState()
+
+    const originChanged =
+      after.origin[0] !== before.origin[0] ||
+      after.origin[1] !== before.origin[1] ||
+      after.origin[2] !== before.origin[2]
+
+    expect(originChanged).toBe(true)
+    expect(after.distance).toBe(before.distance)
+    expect(after.yaw).toBe(before.yaw)
+    expect(after.pitch).toBe(before.pitch)
+  })
+
+  it('shift + horizontal scroll should also pan', async () => {
+    const before = await getState()
+    await dispatchWheel({ deltaX: 100, shiftKey: true })
+    const after = await getState()
+
+    const originChanged =
+      after.origin[0] !== before.origin[0] ||
+      after.origin[1] !== before.origin[1] ||
+      after.origin[2] !== before.origin[2]
+
+    expect(originChanged).toBe(true)
+  })
+
+  it('scroll down should zoom out (increase distance)', async () => {
+    const before = await getState()
+    await dispatchWheel({ deltaY: 100 }) // scroll down = positive deltaY
+    const after = await getState()
+
+    expect(after.distance).toBeGreaterThan(before.distance)
+  })
+
+  it('scroll up should zoom in (decrease distance)', async () => {
+    const before = await getState()
+    await dispatchWheel({ deltaY: -100 }) // scroll up = negative deltaY
+    const after = await getState()
+
+    expect(after.distance).toBeLessThan(before.distance)
+  })
+})
+
+describe('MapHandles wheel options', () => {
+  async function testWithOptions(
+    options: string,
+    test: (getState: () => Promise<any>, dispatchWheel: (opts: any) => Promise<void>) => Promise<void>,
+  ) {
+    const context = await browser.newContext(devices['Desktop Chrome'])
+    const viewport = devices['Desktop Chrome'].viewport!
+    const page = await context.newPage()
+    await page.goto(`http://localhost:3456?${options}`)
+    await page.waitForFunction(() => typeof window.getState === 'function')
+
+    const getState = () => page.evaluate(() => window.getState())
+    const dispatchWheel = async (opts: any) => {
+      await page.mouse.move(viewport.width / 2, viewport.height / 2)
+      await page.evaluate((o) => {
+        const event = new WheelEvent('wheel', {
+          deltaX: o.deltaX ?? 0,
+          deltaY: o.deltaY ?? 0,
+          ctrlKey: o.ctrlKey ?? false,
+          shiftKey: o.shiftKey ?? false,
+          bubbles: true,
+          cancelable: true,
+        })
+        document.getElementById('canvas')!.dispatchEvent(event)
+      }, opts)
+      await page.waitForTimeout(50)
+    }
+
+    try {
+      await test(getState, dispatchWheel)
+    } finally {
+      await context.close()
+    }
+  }
+
+  it('pitch=false should disable ctrl+scroll', async () => {
+    await testWithOptions('pitch=false', async (getState, dispatchWheel) => {
+      const before = await getState()
+      await dispatchWheel({ deltaY: 100, ctrlKey: true })
+      const after = await getState()
+
+      expect(after.pitch).toBe(before.pitch)
+    })
+  })
+
+  it('pan=false should disable shift+scroll', async () => {
+    await testWithOptions('pan=false', async (getState, dispatchWheel) => {
+      const before = await getState()
+      await dispatchWheel({ deltaY: 100, shiftKey: true })
+      const after = await getState()
+
+      const originChanged =
+        after.origin[0] !== before.origin[0] ||
+        after.origin[1] !== before.origin[1] ||
+        after.origin[2] !== before.origin[2]
+
+      expect(originChanged).toBe(false)
+    })
+  })
+
+  it('zoom=false should disable vertical scroll zoom', async () => {
+    await testWithOptions('zoom=false', async (getState, dispatchWheel) => {
+      const before = await getState()
+      await dispatchWheel({ deltaY: 100 })
+      const after = await getState()
+
+      expect(after.distance).toBe(before.distance)
+    })
+  })
+
+  it('yaw=false should disable horizontal scroll yaw', async () => {
+    await testWithOptions('yaw=false', async (getState, dispatchWheel) => {
+      const before = await getState()
+      await dispatchWheel({ deltaX: 100 })
+      const after = await getState()
+
+      expect(after.yaw).toBe(before.yaw)
+    })
+  })
+})

--- a/packages/pointer-events/bench/pointer.bench.ts
+++ b/packages/pointer-events/bench/pointer.bench.ts
@@ -1,7 +1,7 @@
-import { bench, describe } from 'vitest'
-import { createRayPointer } from '../src/pointer/index.js'
 import { BoxGeometry, Mesh, Object3D, PerspectiveCamera, Raycaster, Scene } from 'three'
+import { bench, describe } from 'vitest'
 import { CombinedPointer } from '../src/combine.js'
+import { createRayPointer } from '../src/pointer/index.js'
 
 const camera = new PerspectiveCamera()
 const combinedPointer = new CombinedPointer(true)

--- a/packages/pointer-events/tests/browser/index.ts
+++ b/packages/pointer-events/tests/browser/index.ts
@@ -1,6 +1,3 @@
-import { PointerEventsMap, forwardHtmlEvents } from '../../src/index.js'
-//@ts-ignore
-import e from './elements.json'
 import {
   Scene,
   OrthographicCamera,
@@ -13,6 +10,9 @@ import {
   Object3DEventMap,
   WebGLRenderer,
 } from 'three'
+import e from './elements.json'
+import { PointerEventsMap, forwardHtmlEvents } from '../../src/index.js'
+//@ts-ignore
 
 const scene = new Scene()
 const canvas = document.getElementById('canvas') as HTMLCanvasElement

--- a/packages/pointer-events/tests/index.spec.ts
+++ b/packages/pointer-events/tests/index.spec.ts
@@ -1,5 +1,5 @@
-import { afterAll, describe, it } from 'vitest'
 import { chromium, devices } from 'playwright'
+import { afterAll, describe, it } from 'vitest'
 import { testSetup } from './utils.js'
 
 const browser = await chromium.launch({ headless: true })

--- a/packages/react/handle/package.json
+++ b/packages/react/handle/package.json
@@ -18,8 +18,13 @@
     "url": "git@github.com:pmndrs/xr.git"
   },
   "files": [
-    "dist"
+    "dist",
+    "src/disable-gestures.css"
   ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./disable-gestures.css": "./src/disable-gestures.css"
+  },
   "publishConfig": {
     "main": "dist/index.js"
   },
@@ -35,10 +40,12 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
-    "@react-three/fiber": "rc"
+    "@react-three/fiber": "rc",
+    "vitest": "^1.0.0"
   },
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
     "check:prettier": "prettier --check src",
     "check:eslint": "eslint \"src/**/*.{ts,tsx}\"",
     "fix:prettier": "prettier --write src",

--- a/packages/react/handle/src/disable-gestures.css
+++ b/packages/react/handle/src/disable-gestures.css
@@ -1,0 +1,4 @@
+body {
+  touch-action: none;
+  overscroll-behavior: none;
+}

--- a/packages/react/handle/src/disable-gestures.ts
+++ b/packages/react/handle/src/disable-gestures.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+
+/**
+ * Prevents browser pinch-zoom by intercepting ctrl+wheel events.
+ * Use with disable-gestures.css for full gesture blocking.
+ */
+export function useDisableGestures() {
+  useEffect(() => {
+    const onWheel = (e: WheelEvent) => {
+      if (e.ctrlKey) e.preventDefault()
+    }
+    addEventListener('wheel', onWheel, { passive: false })
+    return () => removeEventListener('wheel', onWheel)
+  }, [])
+}

--- a/packages/react/handle/src/handles/screen.tsx
+++ b/packages/react/handle/src/handles/screen.tsx
@@ -75,6 +75,14 @@ function useScreenHandles(
   handles.zoom.customApply = apply
   handles.zoom.speed = typeof zoom === 'boolean' ? undefined : zoom?.speed
   handles.zoom.filter = typeof zoom === 'boolean' ? undefined : zoom?.filter
+
+  // Wheel (MapHandles only)
+  useEffect(() => {
+    if (disabled) return
+    if ('bindWheel' in handles) {
+      return (handles as MapHandlesImpl).bindWheel(scene)
+    }
+  }, [handles, disabled, scene])
 }
 
 export function useApplyScreenCameraState(

--- a/packages/react/handle/src/index.ts
+++ b/packages/react/handle/src/index.ts
@@ -1,4 +1,5 @@
 export * from './hook.js'
+export * from './disable-gestures.js'
 export * from './component.js'
 export * from './handles/index.js'
 export {

--- a/packages/react/handle/tests/disable-gestures.spec.ts
+++ b/packages/react/handle/tests/disable-gestures.spec.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest'
-import { useDisableGestures } from '../src/disable-gestures'
 import { existsSync, readFileSync } from 'fs'
 import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+import { useDisableGestures } from '../src/disable-gestures.js'
 
 describe('disable-gestures', () => {
   it('useDisableGestures should be a function', () => {

--- a/packages/react/handle/tests/disable-gestures.spec.ts
+++ b/packages/react/handle/tests/disable-gestures.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { useDisableGestures } from '../src/disable-gestures'
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+
+describe('disable-gestures', () => {
+  it('useDisableGestures should be a function', () => {
+    expect(typeof useDisableGestures).toBe('function')
+  })
+
+  it('disable-gestures.css should exist', () => {
+    const cssPath = resolve(__dirname, '../src/disable-gestures.css')
+    expect(existsSync(cssPath)).toBe(true)
+  })
+
+  it('disable-gestures.css should contain touch-action and overscroll-behavior', () => {
+    const cssPath = resolve(__dirname, '../src/disable-gestures.css')
+    const css = readFileSync(cssPath, 'utf-8')
+    expect(css).toContain('touch-action')
+    expect(css).toContain('overscroll-behavior')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
         version: link:../../packages/xr
       '@react-three/uikit':
         specifier: ^0.5.3
-        version: 0.5.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.5.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -134,10 +134,10 @@ importers:
         version: link:../../packages/react/xr
       meshline:
         specifier: ^3.3.1
-        version: 3.3.1(three@0.173.0)
+        version: 3.3.1(three@0.182.0)
       postprocessing:
         specifier: ^6.36.6
-        version: 6.36.6(three@0.173.0)
+        version: 6.36.6(three@0.182.0)
       zustand:
         specifier: ^4.5.2
         version: 4.5.6(@types/react@19.0.8)(react@19.0.0)
@@ -164,7 +164,7 @@ importers:
         version: link:../../packages/react/handle
       '@react-three/rapier':
         specifier: ^1.5.0
-        version: 1.5.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(react@19.0.0)(three@0.173.0)
+        version: 1.5.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(react@19.0.0)(three@0.182.0)
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -185,7 +185,7 @@ importers:
     dependencies:
       '@react-three/uikit':
         specifier: ^0.8.21
-        version: 0.8.21(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.8.21(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -199,11 +199,23 @@ importers:
         specifier: workspace:~
         version: link:../../packages/react/xr
 
+  examples/map-handles:
+    dependencies:
+      '@pmndrs/pointer-events':
+        specifier: workspace:~
+        version: link:../../packages/pointer-events
+      '@react-three/handle':
+        specifier: workspace:~
+        version: link:../../packages/react/handle
+      '@react-three/xr':
+        specifier: workspace:~
+        version: link:../../packages/react/xr
+
   examples/minecraft:
     dependencies:
       '@react-three/rapier':
         specifier: ^1.4.0
-        version: 1.5.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(react@19.0.0)(three@0.173.0)
+        version: 1.5.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(react@19.0.0)(three@0.182.0)
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -224,7 +236,7 @@ importers:
     dependencies:
       '@react-three/rapier':
         specifier: ^1.4.0
-        version: 1.5.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(react@19.0.0)(three@0.173.0)
+        version: 1.5.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(react@19.0.0)(three@0.182.0)
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -254,7 +266,7 @@ importers:
         version: link:../../packages/pointer-events
       '@react-three/cannon':
         specifier: ^6.6.0
-        version: 6.6.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(react@19.0.0)(three@0.173.0)(typescript@5.7.3)
+        version: 6.6.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(react@19.0.0)(three@0.182.0)(typescript@5.7.3)
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -278,16 +290,16 @@ importers:
         version: link:../../packages/react/xr
       maath:
         specifier: ^0.10.8
-        version: 0.10.8(@types/three@0.173.0)(three@0.173.0)
+        version: 0.10.8(@types/three@0.173.0)(three@0.182.0)
 
   examples/secondary-input-sources:
     dependencies:
       '@react-three/uikit':
         specifier: ^0.4.1
-        version: 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/uikit-lucide':
         specifier: ^0.4.1
-        version: 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -311,13 +323,13 @@ importers:
         version: link:../../packages/react/handle
       '@react-three/uikit':
         specifier: ^0.8.3
-        version: 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/uikit-default':
         specifier: ^0.8.3
-        version: 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/uikit-lucide':
         specifier: ^0.8.3
-        version: 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -341,10 +353,10 @@ importers:
         version: link:../../packages/pointer-events
       '@pmndrs/uikit':
         specifier: ^0.4.4
-        version: 0.4.4(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.4.4(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@pmndrs/uikit-lucide':
         specifier: ^0.4.4
-        version: 0.4.4(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.4.4(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@pmndrs/xr':
         specifier: workspace:~
         version: link:../../packages/xr
@@ -356,10 +368,10 @@ importers:
         version: 1.8.0
       '@react-three/uikit':
         specifier: ^0.4.1
-        version: 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/uikit-lucide':
         specifier: ^0.4.1
-        version: 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+        version: 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -372,6 +384,19 @@ importers:
       zustand:
         specifier: ^4.5.2
         version: 4.5.6(@types/react@19.0.8)(react@19.0.0)
+    devDependencies:
+      playwright:
+        specifier: ^1.40.0
+        version: 1.50.1
+      three:
+        specifier: '*'
+        version: 0.182.0
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.14(@types/node@22.13.0)
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@22.13.0)
 
   packages/pointer-events:
     devDependencies:
@@ -406,6 +431,9 @@ importers:
       '@react-three/fiber':
         specifier: rc
         version: 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0)
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@22.13.0)
 
   packages/react/xr:
     dependencies:
@@ -787,6 +815,10 @@ packages:
     peerDependencies:
       iwer: ^2.0.0
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -1087,6 +1119,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
 
@@ -1262,6 +1297,9 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
   '@vitest/expect@2.1.8':
     resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}
 
@@ -1279,14 +1317,26 @@ packages:
   '@vitest/pretty-format@2.1.8':
     resolution: {integrity: sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==}
 
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
   '@vitest/runner@2.1.8':
     resolution: {integrity: sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
 
   '@vitest/snapshot@2.1.8':
     resolution: {integrity: sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==}
 
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
   '@vitest/spy@2.1.8':
     resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
   '@vitest/utils@2.1.8':
     resolution: {integrity: sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==}
@@ -1308,6 +1358,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1326,6 +1381,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -1382,6 +1441,9 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1488,6 +1550,10 @@ packages:
     resolution: {integrity: sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==}
     engines: {node: '>=12.13'}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chai@5.1.2:
     resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
     engines: {node: '>=12'}
@@ -1499,6 +1565,9 @@ packages:
   chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -1536,6 +1605,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1610,6 +1682,10 @@ packages:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -1640,6 +1716,10 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -1869,6 +1949,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+
   expect-type@1.1.0:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
     engines: {node: '>=12.0.0'}
@@ -1967,6 +2051,9 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-intrinsic@1.2.7:
     resolution: {integrity: sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==}
     engines: {node: '>= 0.4'}
@@ -1974,6 +2061,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -2062,6 +2153,10 @@ packages:
 
   hls.js@1.5.20:
     resolution: {integrity: sha512-uu0VXUK52JhihhnN/MVVo1lvqNNuhoxkonqgO3IpjvQiGpJBdIXMGkofjQb/j9zvV7a1SW8U9g1FslWx/1HOiQ==}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2190,6 +2285,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -2253,6 +2352,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -2318,6 +2420,10 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2336,6 +2442,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
@@ -2372,6 +2481,9 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2387,6 +2499,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -2409,6 +2525,9 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
   mocha@10.8.2:
     resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
@@ -2438,6 +2557,10 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -2481,6 +2604,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -2500,6 +2627,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -2524,6 +2655,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -2537,6 +2672,12 @@ packages:
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -2556,6 +2697,9 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   playwright-core@1.50.1:
     resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
@@ -2649,6 +2793,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   promise-worker-transferable@1.0.4:
     resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
@@ -2688,6 +2836,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-reconciler@0.31.0:
     resolution: {integrity: sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==}
@@ -2919,9 +3070,16 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   styled-components@6.1.13:
     resolution: {integrity: sha512-M0+N2xSnAtwcVAQeFEsGWFFxXDftHUD7XrKla06QbpUMmbmtFBMMTcKWvFXtWxuD5qQkB8iU5gk6QASlx2ZRMw==}
@@ -2990,11 +3148,18 @@ packages:
   three@0.173.0:
     resolution: {integrity: sha512-AUwVmViIEUgBwxJJ7stnF0NkPpZxx1aZ6WiAbQ/Qq61h6I9UR4grXtZDmO8mnlaNORhHnIBlXJ1uBxILEKuVyw==}
 
+  three@0.182.0:
+    resolution: {integrity: sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
 
   tinypool@1.0.2:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
@@ -3002,6 +3167,10 @@ packages:
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
@@ -3078,6 +3247,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
@@ -3123,6 +3296,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -3175,6 +3351,11 @@ packages:
       react:
         optional: true
 
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@2.1.8:
     resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -3209,6 +3390,31 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@2.1.8:
@@ -3325,6 +3531,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
@@ -3663,6 +3873,10 @@ snapshots:
       three: 0.165.0
       ts-proto: 2.6.1
 
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -3709,9 +3923,9 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@pmndrs/cannon-worker-api@2.4.0(three@0.173.0)':
+  '@pmndrs/cannon-worker-api@2.4.0(three@0.182.0)':
     dependencies:
-      three: 0.173.0
+      three: 0.182.0
 
   '@pmndrs/handle@6.6.1(@types/react@19.0.8)(react@18.3.1)':
     dependencies:
@@ -3728,54 +3942,54 @@ snapshots:
 
   '@pmndrs/pointer-events@6.6.1': {}
 
-  '@pmndrs/uikit-lucide@0.4.4(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@pmndrs/uikit-lucide@0.4.4(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
-      '@pmndrs/uikit': 0.4.4(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@pmndrs/uikit': 0.4.4(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
     transitivePeerDependencies:
       - three
       - ts-node
 
-  '@pmndrs/uikit@0.4.4(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@pmndrs/uikit@0.4.4(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
       '@preact/signals-core': 1.8.0
       inline-style-parser: 0.2.4
       node-html-parser: 6.1.13
-      three: 0.173.0
+      three: 0.182.0
       tw-to-css: 0.0.12(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - ts-node
 
-  '@pmndrs/uikit@0.5.4(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@pmndrs/uikit@0.5.4(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
       '@preact/signals-core': 1.8.0
       inline-style-parser: 0.2.4
       node-html-parser: 6.1.13
-      three: 0.173.0
+      three: 0.182.0
       tw-to-css: 0.0.12(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - ts-node
 
-  '@pmndrs/uikit@0.8.21(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@pmndrs/uikit@0.8.21(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
       '@pmndrs/msdfonts': 0.8.21
       '@preact/signals-core': 1.8.0
       inline-style-parser: 0.2.4
       node-html-parser: 6.1.13
-      three: 0.173.0
+      three: 0.182.0
       tw-to-css: 0.0.12(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       yoga-layout: 3.2.1
     transitivePeerDependencies:
       - ts-node
 
-  '@pmndrs/uikit@0.8.7(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@pmndrs/uikit@0.8.7(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
       '@pmndrs/msdfonts': 0.8.7
       '@preact/signals-core': 1.8.0
       inline-style-parser: 0.2.4
       node-html-parser: 6.1.13
-      three: 0.173.0
+      three: 0.182.0
       tw-to-css: 0.0.12(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       yoga-layout: 3.2.1
     transitivePeerDependencies:
@@ -3788,14 +4002,14 @@ snapshots:
       '@preact/signals-core': 1.8.0
       preact: 10.25.4
 
-  '@react-three/cannon@6.6.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(react@19.0.0)(three@0.173.0)(typescript@5.7.3)':
+  '@react-three/cannon@6.6.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(react@19.0.0)(three@0.182.0)(typescript@5.7.3)':
     dependencies:
-      '@pmndrs/cannon-worker-api': 2.4.0(three@0.173.0)
-      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0)
+      '@pmndrs/cannon-worker-api': 2.4.0(three@0.182.0)
+      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0)
       cannon-es: 0.20.0
-      cannon-es-debugger: 1.0.0(cannon-es@0.20.0)(three@0.173.0)(typescript@5.7.3)
+      cannon-es-debugger: 1.0.0(cannon-es@0.20.0)(three@0.182.0)(typescript@5.7.3)
       react: 19.0.0
-      three: 0.173.0
+      three: 0.182.0
     transitivePeerDependencies:
       - typescript
 
@@ -3861,19 +4075,41 @@ snapshots:
       - '@types/react'
       - immer
 
-  '@react-three/rapier@1.5.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(react@19.0.0)(three@0.173.0)':
+  '@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0)':
+    dependencies:
+      '@babel/runtime': 7.26.7
+      '@types/debounce': 1.2.4
+      '@types/react-reconciler': 0.28.9(@types/react@19.0.8)
+      '@types/webxr': 0.5.21
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      debounce: 1.2.1
+      its-fine: 1.2.5(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-reconciler: 0.31.0(react@19.0.0)
+      scheduler: 0.25.0
+      suspend-react: 0.1.3(react@19.0.0)
+      three: 0.182.0
+      zustand: 4.5.6(@types/react@19.0.8)(react@19.0.0)
+    optionalDependencies:
+      react-dom: 19.0.0(react@19.0.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@react-three/rapier@1.5.0(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(react@19.0.0)(three@0.182.0)':
     dependencies:
       '@dimforge/rapier3d-compat': 0.14.0
-      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0)
+      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0)
       react: 19.0.0
       suspend-react: 0.1.3(react@19.0.0)
-      three: 0.173.0
-      three-stdlib: 2.35.13(three@0.173.0)
+      three: 0.182.0
+      three-stdlib: 2.35.13(three@0.182.0)
 
-  '@react-three/uikit-default@0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@react-three/uikit-default@0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
-      '@react-three/uikit': 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
-      '@react-three/uikit-lucide': 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@react-three/uikit': 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@react-three/uikit-lucide': 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       tunnel-rat: 0.1.2(@types/react@19.0.8)(react@19.0.0)
     transitivePeerDependencies:
       - '@react-three/fiber'
@@ -3883,9 +4119,9 @@ snapshots:
       - three
       - ts-node
 
-  '@react-three/uikit-lucide@0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@react-three/uikit-lucide@0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
-      '@react-three/uikit': 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@react-three/uikit': 0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
     transitivePeerDependencies:
       - '@react-three/fiber'
       - '@types/react'
@@ -3894,9 +4130,9 @@ snapshots:
       - three
       - ts-node
 
-  '@react-three/uikit-lucide@0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@react-three/uikit-lucide@0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
-      '@react-three/uikit': 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@react-three/uikit': 0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
     transitivePeerDependencies:
       - '@react-three/fiber'
       - '@types/react'
@@ -3905,11 +4141,11 @@ snapshots:
       - three
       - ts-node
 
-  '@react-three/uikit@0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@react-three/uikit@0.4.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
-      '@pmndrs/uikit': 0.4.4(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@pmndrs/uikit': 0.4.4(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@preact/signals-core': 1.8.0
-      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0)
+      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0)
       chalk: 5.4.1
       commander: 12.1.0
       ora: 8.1.1
@@ -3924,11 +4160,11 @@ snapshots:
       - three
       - ts-node
 
-  '@react-three/uikit@0.5.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@react-three/uikit@0.5.4(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
-      '@pmndrs/uikit': 0.5.4(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@pmndrs/uikit': 0.5.4(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@preact/signals-core': 1.8.0
-      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0)
+      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0)
       chalk: 5.4.1
       commander: 12.1.0
       ora: 8.1.1
@@ -3943,11 +4179,11 @@ snapshots:
       - three
       - ts-node
 
-  '@react-three/uikit@0.8.21(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@react-three/uikit@0.8.21(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
-      '@pmndrs/uikit': 0.8.21(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@pmndrs/uikit': 0.8.21(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@preact/signals-core': 1.8.0
-      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0)
+      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0)
       chalk: 5.4.1
       commander: 12.1.0
       ora: 8.1.1
@@ -3963,11 +4199,11 @@ snapshots:
       - three
       - ts-node
 
-  '@react-three/uikit@0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+  '@react-three/uikit@0.8.7(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0))(@types/react@19.0.8)(react@19.0.0)(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
-      '@pmndrs/uikit': 0.8.7(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@pmndrs/uikit': 0.8.7(three@0.182.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@preact/signals-core': 1.8.0
-      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0)
+      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.182.0)
       chalk: 5.4.1
       commander: 12.1.0
       ora: 8.1.1
@@ -4060,6 +4296,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sinclair/typebox@0.27.8': {}
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -4263,6 +4501,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
   '@vitest/expect@2.1.8':
     dependencies:
       '@vitest/spy': 2.1.8
@@ -4282,10 +4526,22 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
   '@vitest/runner@2.1.8':
     dependencies:
       '@vitest/utils': 2.1.8
       pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      pretty-format: 29.7.0
 
   '@vitest/snapshot@2.1.8':
     dependencies:
@@ -4293,9 +4549,20 @@ snapshots:
       magic-string: 0.30.17
       pathe: 1.1.2
 
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
   '@vitest/spy@2.1.8':
     dependencies:
       tinyspy: 3.0.2
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
 
   '@vitest/utils@2.1.8':
     dependencies:
@@ -4315,6 +4582,8 @@ snapshots:
 
   acorn@8.14.0: {}
 
+  acorn@8.15.0: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4331,6 +4600,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
 
@@ -4413,6 +4684,8 @@ snapshots:
       get-intrinsic: 1.2.7
       is-array-buffer: 3.0.5
 
+  assertion-error@1.1.0: {}
+
   assertion-error@2.0.1: {}
 
   async-function@1.0.0: {}
@@ -4493,16 +4766,26 @@ snapshots:
 
   caniuse-lite@1.0.30001696: {}
 
-  cannon-es-debugger@1.0.0(cannon-es@0.20.0)(three@0.173.0)(typescript@5.7.3):
+  cannon-es-debugger@1.0.0(cannon-es@0.20.0)(three@0.182.0)(typescript@5.7.3):
     dependencies:
       cannon-es: 0.20.0
-      three: 0.173.0
+      three: 0.182.0
     optionalDependencies:
       typescript: 5.7.3
 
   cannon-es@0.20.0: {}
 
   case-anything@2.1.13: {}
+
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
 
   chai@5.1.2:
     dependencies:
@@ -4518,6 +4801,10 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.4.1: {}
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   check-error@2.1.1: {}
 
@@ -4556,6 +4843,8 @@ snapshots:
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4625,6 +4914,10 @@ snapshots:
 
   decamelize@4.0.0: {}
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -4652,6 +4945,8 @@ snapshots:
   detect-libc@1.0.3: {}
 
   didyoumean@1.2.2: {}
+
+  diff-sequences@29.6.3: {}
 
   diff@4.0.2: {}
 
@@ -5010,6 +5305,18 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+
   expect-type@1.1.0: {}
 
   extend@3.0.2: {}
@@ -5097,6 +5404,8 @@ snapshots:
 
   get-east-asian-width@1.3.0: {}
 
+  get-func-name@2.0.2: {}
+
   get-intrinsic@1.2.7:
     dependencies:
       call-bind-apply-helpers: 1.0.1
@@ -5114,6 +5423,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -5208,6 +5519,8 @@ snapshots:
   he@1.2.0: {}
 
   hls.js@1.5.20: {}
+
+  human-signals@5.0.0: {}
 
   ieee754@1.2.1: {}
 
@@ -5330,6 +5643,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.3
 
+  is-stream@3.0.0: {}
+
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.3
@@ -5397,6 +5712,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -5449,6 +5766,11 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 1.3.1
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -5469,6 +5791,10 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   loupe@3.1.3: {}
 
   lru-cache@10.4.3: {}
@@ -5483,6 +5809,11 @@ snapshots:
     dependencies:
       '@types/three': 0.173.0
       three: 0.173.0
+
+  maath@0.10.8(@types/three@0.173.0)(three@0.182.0):
+    dependencies:
+      '@types/three': 0.173.0
+      three: 0.182.0
 
   magic-string@0.30.17:
     dependencies:
@@ -5503,11 +5834,17 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  merge-stream@2.0.0: {}
+
   merge2@1.4.1: {}
 
   meshline@3.3.1(three@0.173.0):
     dependencies:
       three: 0.173.0
+
+  meshline@3.3.1(three@0.182.0):
+    dependencies:
+      three: 0.182.0
 
   meshoptimizer@0.18.1: {}
 
@@ -5515,6 +5852,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -5533,6 +5872,13 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
 
   mocha@10.8.2:
     dependencies:
@@ -5577,6 +5923,10 @@ snapshots:
   node-releases@2.0.19: {}
 
   normalize-path@3.0.0: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
 
   nth-check@2.1.1:
     dependencies:
@@ -5629,6 +5979,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -5664,6 +6018,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
@@ -5680,6 +6038,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
@@ -5691,6 +6051,10 @@ snapshots:
 
   pathe@1.1.2: {}
 
+  pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
+
   pathval@2.0.0: {}
 
   picocolors@1.1.1: {}
@@ -5700,6 +6064,12 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
 
   playwright-core@1.50.1: {}
 
@@ -5768,9 +6138,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postprocessing@6.36.6(three@0.173.0):
+  postprocessing@6.36.6(three@0.182.0):
     dependencies:
-      three: 0.173.0
+      three: 0.182.0
 
   potpack@1.0.2: {}
 
@@ -5783,6 +6153,12 @@ snapshots:
       fast-diff: 1.3.0
 
   prettier@3.6.2: {}
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
 
   promise-worker-transferable@1.0.4:
     dependencies:
@@ -5824,6 +6200,8 @@ snapshots:
       scheduler: 0.25.0
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
 
   react-reconciler@0.31.0(react@19.0.0):
     dependencies:
@@ -6114,7 +6492,13 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@3.0.0: {}
+
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   styled-components@6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -6213,17 +6597,33 @@ snapshots:
       potpack: 1.0.2
       three: 0.173.0
 
+  three-stdlib@2.35.13(three@0.182.0):
+    dependencies:
+      '@types/draco3d': 1.4.10
+      '@types/offscreencanvas': 2019.7.3
+      '@types/webxr': 0.5.21
+      draco3d: 1.5.7
+      fflate: 0.6.10
+      potpack: 1.0.2
+      three: 0.182.0
+
   three@0.165.0: {}
 
   three@0.173.0: {}
+
+  three@0.182.0: {}
 
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
 
+  tinypool@0.8.4: {}
+
   tinypool@1.0.2: {}
 
   tinyrainbow@1.2.0: {}
+
+  tinyspy@2.2.1: {}
 
   tinyspy@3.0.2: {}
 
@@ -6315,6 +6715,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-detect@4.1.0: {}
+
   type-fest@0.20.2: {}
 
   typed-array-buffer@1.0.3:
@@ -6372,6 +6774,8 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
+  ufo@1.6.1: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.3
@@ -6420,6 +6824,24 @@ snapshots:
       '@types/react': 19.0.8
       react: 19.0.0
 
+  vite-node@1.6.1(@types/node@22.13.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0(supports-color@8.1.1)
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.14(@types/node@22.13.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@2.1.8(@types/node@20.17.16):
     dependencies:
       cac: 6.7.14
@@ -6455,6 +6877,40 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.0
       fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@22.13.0):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.0(supports-color@8.1.1)
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.8.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.14(@types/node@22.13.0)
+      vite-node: 1.6.1(@types/node@22.13.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.13.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@2.1.8(@types/node@20.17.16):
     dependencies:
@@ -6596,6 +7052,8 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   yoga-layout@3.2.1: {}
 


### PR DESCRIPTION
Adds trackpad gesture support for MapHandles:
- 2-finger swipe horizontal → yaw (was non-functional)
- Pinch → pitch
- Shift + 2-finger swipe → pan
- `useDisableGestures` hook to prevent browser pinch-zoom interference
- `MapHandlesWheelOptions` to disable gestures (for legacy users with custom handlers, potentially a breaking change) or configure speeds
- Playwright tests

See `examples/map-handles` for usage.

### Notes

- Safari touchpads (gestures) not yet supported; I can make another PR after this lands, but I don't actually have an apple device to test it
- Cannot distinguish mouse wheel from trackpad cross-browser, so mouse wheel behaves the same. See: https://github.com/w3c/pointerevents/issues/596
