### PR TITLE
docs: update CONTRIBUTING.md (remove -r copy instruction)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,6 @@ To get started, make sure you have [Node](https://nodejs.org) and [PNPM](https:/
 
 ```bash
 pnpm i
-pnpm -r copy
 pnpm -r build
 ```
 


### PR DESCRIPTION
Removed instructions to run -r copy, as it's unnecessary as of 95be8b88