### PR TITLE
fix: use ReturnType<typeof setTimeout> for build compatibility

### DIFF
--- a/packages/xr/src/store.ts
+++ b/packages/xr/src/store.ts
@@ -854,7 +854,7 @@ function createBindToSession(
 
     //for debouncing the input source and tracked source changes
     const inputSourceChangesList: Parameters<typeof syncXRInputSourceStates>[2] & Array<unknown> = []
-    let inputSourceChangesTimeout: number | undefined
+    let inputSourceChangesTimeout: ReturnType<typeof setTimeout> | undefined
 
     const applySourcesChange = () => {
       inputSourceChangesTimeout = undefined


### PR DESCRIPTION
Build was failing with `Type 'Timeout' is not assignable to type 'number'` because `@types/node` (peer dep of `vite/ts-node`) makes `setTimeout` return `NodeJS.Timeout` instead of `number`.

Fixed by using `ReturnType<typeof setTimeout>` which works in both environments.