### PR TITLE
fix: pointer-events vanilla typings #483

### DIFF
--- a/packages/pointer-events/src/event.ts
+++ b/packages/pointer-events/src/event.ts
@@ -2,7 +2,7 @@ import { BaseEvent, Face, Object3D, Quaternion, Ray, Vector2, Vector3 } from 'th
 import { HtmlEvent, Properties } from './html-event.js'
 import { Intersection as ThreeIntersection } from './intersections/index.js'
 import { Pointer } from './pointer.js'
-import type { Camera, IntersectionEvent, Intersection } from '@react-three/fiber/dist/declarations/src/core/events.js'
+import type { Camera, IntersectionEvent, Intersection } from './r3f-compat.js'
 
 export type PointerEventsMap = {
   [Key in keyof PointerEventsHandlers as EventHandlerToEventName<Key>]-?: PointerEventsHandlers[Key]

--- a/packages/pointer-events/src/index.ts
+++ b/packages/pointer-events/src/index.ts
@@ -1,6 +1,6 @@
 import type { PointerEvent, WheelEvent } from './event.js'
 import type { AllowedPointerEvents, AllowedPointerEventsType } from './pointer.js'
-import type { createStore } from '@react-three/fiber/dist/declarations/src/core/store.js'
+import type { R3FInstance } from './r3f-compat.js'
 
 declare module 'three' {
   interface Object3DEventMap {
@@ -19,11 +19,7 @@ declare module 'three' {
   }
 
   interface Object3D {
-    __r3f?: {
-      eventCount: number
-      handlers: Record<string, ((e: any) => void) | undefined>
-      root: ReturnType<typeof createStore>
-    }
+    __r3f?: R3FInstance
     /**
      * undefined and true means the transformation is ready
      * false means transformation is not ready

--- a/packages/pointer-events/src/r3f-compat.ts
+++ b/packages/pointer-events/src/r3f-compat.ts
@@ -1,0 +1,39 @@
+/**
+ * R3F compatibility types - minimal interfaces for @react-three/fiber compatibility
+ * without requiring it as a dependency.
+ */
+
+import type { Intersection as ThreeIntersection } from './intersections/index.js'
+import type { Object3D, OrthographicCamera, PerspectiveCamera, Ray, Vector2, Vector3 } from 'three'
+
+export type Camera = OrthographicCamera | PerspectiveCamera
+
+export interface Intersection extends ThreeIntersection {
+  eventObject: Object3D
+}
+
+export interface IntersectionEvent<TSourceEvent> extends Intersection {
+  intersections: Intersection[]
+  unprojectedPoint: Vector3
+  pointer: Vector2
+  delta: number
+  ray: Ray
+  camera: Camera
+  stopPropagation: () => void
+  nativeEvent: TSourceEvent
+  stopped: boolean
+}
+
+export interface R3FState {
+  onPointerMissed?: (event: MouseEvent) => void
+}
+
+export interface R3FStore {
+  getState: () => R3FState
+}
+
+export interface R3FInstance {
+  eventCount: number
+  handlers: Record<string, ((e: unknown) => void) | undefined>
+  root: R3FStore
+}


### PR DESCRIPTION
closes https://github.com/pmndrs/xr/issues/483 as per the hard coding suggestion. 


@bbohlender ,

I'm a little worried about this approach being hard to maintain as types in R3F will drift over time. I suggest having a dedicated R3F wrapper package. But your call!