### PR TITLE
fix: handle stale XRSpace during VR session re-entry

### DIFF
--- a/packages/xr/src/space.ts
+++ b/packages/xr/src/space.ts
@@ -13,7 +13,15 @@ export function createGetXRSpaceMatrix(
     if (resolvedReferenceSpace == null) {
       return false
     }
-    const pose = frame?.getPose(space, resolvedReferenceSpace)
+    let pose: XRPose | undefined
+    try {
+      pose = frame?.getPose(space, resolvedReferenceSpace)
+    } catch {
+      // XRSpace from a previous session may still be referenced during
+      // the first few frames after re-entering VR, causing an
+      // InvalidStateError ("XRSpace and XRFrame sessions do not match").
+      return false
+    }
     if (pose == null) {
       return false
     }


### PR DESCRIPTION
## Problem

Fixes #473

Re-entering a VR session (exit VR → enter VR again) causes an uncaught `InvalidStateError`:

```
DOMException: Failed to execute 'getPose' on 'XRFrame': XRSpace and XRFrame sessions do not match.
```

This happens because `XRSpace` objects from the previous session (attached to `Object3D.xrSpace`) remain referenced during the first few frames of the new session. When `createGetXRSpaceMatrix` calls `frame.getPose(space, referenceSpace)` with these stale spaces, the browser throws.

**Affected devices**: Pico 4, Pico Ultra, Android smartphones (Chrome)
**Unaffected**: Quest 3 (does not throw on session mismatch)

## Fix

Wrap the `frame.getPose()` call in `createGetXRSpaceMatrix` (`space.ts`) with a try-catch. When the error is caught, the function returns `false` (same as when `pose == null`), allowing the frame loop to continue. The stale `XRSpace` references are naturally replaced within a few frames as the new session's input sources are registered.

## Note

A more thorough fix could proactively invalidate/clean up `XRSpace` references on `Object3D` nodes when a session ends, but this minimal change is the least invasive way to prevent the crash.