### PR TITLE
fix: add invalidate call in handles to support frameloop="demand"

### DIFF
--- a/packages/react/handle/src/handles/utils.ts
+++ b/packages/react/handle/src/handles/utils.ts
@@ -9,6 +9,7 @@ type ControlsProto = {
 
 export function useApplyThatDisablesDefaultControls<T>(apply: HandleOptions<T>['apply']): HandleOptions<T>['apply'] {
   const controls = useThree((s) => s.controls as unknown as ControlsProto | undefined)
+  const invalidate = useThree((s) => s.invalidate)
   return useCallback(
     (state: HandleState<T>, target: Object3D) => {
       if (controls != null && state.first) {
@@ -17,9 +18,11 @@ export function useApplyThatDisablesDefaultControls<T>(apply: HandleOptions<T>['
       if (controls != null && state.last) {
         controls.enabled = true
       }
-      return (apply ?? defaultApply)(state, target)
+      const result = (apply ?? defaultApply)(state, target)
+      invalidate()
+      return result
     },
-    [apply, controls],
+    [apply, controls, invalidate],
   )
 }
 

--- a/packages/react/handle/src/hook.ts
+++ b/packages/react/handle/src/hook.ts
@@ -1,5 +1,5 @@
-import { HandleOptions as BaseHandleOptions, HandleStore } from '@pmndrs/handle'
-import { useFrame } from '@react-three/fiber'
+import { HandleOptions as BaseHandleOptions, HandleStore, defaultApply } from '@pmndrs/handle'
+import { useFrame, useThree } from '@react-three/fiber'
 import { RefObject, useEffect, useMemo, useRef } from 'react'
 import { Object3D } from 'three'
 
@@ -29,12 +29,27 @@ export function useHandle<T>(
   options: HandleOptions<T> = {},
   getHandleOptions?: () => HandleOptions<T>,
 ): HandleStore<T> {
+  const invalidate = useThree((s) => s.invalidate)
   const optionsRef = useRef(options)
   optionsRef.current = options
   const getHandleOptionsRef = useRef(getHandleOptions)
   getHandleOptionsRef.current = getHandleOptions
+  const invalidateRef = useRef(invalidate)
+  invalidateRef.current = invalidate
   const store = useMemo(
-    () => new HandleStore(target, () => ({ ...getHandleOptionsRef.current?.(), ...optionsRef.current })),
+    () =>
+      new HandleStore(target, () => {
+        const opts = { ...getHandleOptionsRef.current?.(), ...optionsRef.current }
+        const apply = opts.apply ?? defaultApply
+        return {
+          ...opts,
+          apply: (state, target) => {
+            const result = apply(state, target)
+            invalidateRef.current()
+            return result
+          },
+        }
+      }),
     [target],
   )
   useFrame((state) => store.update(state.clock.getElapsedTime()), -1)

--- a/packages/react/handle/src/hook.ts
+++ b/packages/react/handle/src/hook.ts
@@ -1,4 +1,4 @@
-import { HandleOptions as BaseHandleOptions, HandleStore, defaultApply } from '@pmndrs/handle'
+import { HandleOptions as BaseHandleOptions, HandleState, HandleStore, defaultApply } from '@pmndrs/handle'
 import { useFrame, useThree } from '@react-three/fiber'
 import { RefObject, useEffect, useMemo, useRef } from 'react'
 import { Object3D } from 'three'
@@ -38,13 +38,23 @@ export function useHandle<T>(
   invalidateRef.current = invalidate
   const store = useMemo(
     () =>
-      new HandleStore(target, () => {
+      new HandleStore<T>(target, () => {
         const opts = { ...getHandleOptionsRef.current?.(), ...optionsRef.current }
-        const apply = opts.apply ?? defaultApply
+        const userApply = opts.apply
+        if (userApply == null) {
+          return {
+            ...opts,
+            apply: (state: HandleState<T>, target: Object3D) => {
+              const result = defaultApply(state, target)
+              invalidateRef.current()
+              return result
+            },
+          }
+        }
         return {
           ...opts,
-          apply: (state, target) => {
-            const result = apply(state, target)
+          apply: (state: HandleState<T>, target: Object3D) => {
+            const result = userApply(state, target)
             invalidateRef.current()
             return result
           },


### PR DESCRIPTION
Adds `invalidate()` calls in the React handle wrapper so that handles work correctly with `frameloop="demand"`.

## Changes

**`packages/react/handle/src/hook.ts`**
- `useHandle` now calls `invalidate()` after the apply function runs, ensuring the frame re-renders when a handle is manipulated in demand mode.

**`packages/react/handle/src/handles/utils.ts`**
- `useApplyThatDisablesDefaultControls` also calls `invalidate()` after apply, covering TransformHandles and PivotHandles.

## Design

The `invalidate()` calls are added exclusively in the React wrapper layer using `useThree((s) => s.invalidate)` from `@react-three/fiber`. The vanilla `@pmndrs/handle` package remains framework-agnostic with no R3F dependency.

When `frameloop="always"` (the default), `invalidate()` is a no-op since frames render continuously, so this is fully backward compatible.

Fixes #404